### PR TITLE
[BigQuery] fix details typing and remove console logs

### DIFF
--- a/jupyterlab_bigquery/src/components/details_panel/dataset_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/dataset_details_panel.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 
-import { DatasetDetailsService } from './service/list_dataset_details';
+import {
+  DatasetDetailsService,
+  DatasetDetails,
+} from './service/list_dataset_details';
 
 interface Props {
   datasetDetailsService: DatasetDetailsService;
@@ -11,8 +14,7 @@ interface Props {
 interface State {
   hasLoaded: boolean;
   isLoading: boolean;
-  // TODO(cxjia): type these details
-  details: any;
+  details: DatasetDetails;
 }
 
 export default class DatasetDetailsPanel extends React.Component<Props, State> {
@@ -21,7 +23,7 @@ export default class DatasetDetailsPanel extends React.Component<Props, State> {
     this.state = {
       hasLoaded: false,
       isLoading: false,
-      details: { details: {} },
+      details: { details: {} } as DatasetDetails,
     };
   }
 
@@ -42,14 +44,12 @@ export default class DatasetDetailsPanel extends React.Component<Props, State> {
   }
 
   private async getDetails() {
-    console.log('starting getDetails');
     try {
       this.setState({ isLoading: true });
       const details = await this.props.datasetDetailsService.listDatasetDetails(
         this.props.dataset_id
       );
       this.setState({ hasLoaded: true, details });
-      console.log('Details: ', this.state.details);
     } catch (err) {
       console.warn('Error retrieving dataset details', err);
     } finally {

--- a/jupyterlab_bigquery/src/components/details_panel/dataset_details_widget.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/dataset_details_widget.tsx
@@ -16,7 +16,6 @@ export class DatasetDetailsWidget extends ReactWidget {
     private readonly name: string
   ) {
     super();
-    console.log('dataset id: ', this.dataset_id);
     this.title.iconClass = 'jp-Icon jp-Icon-20 jp-BigQueryIcon';
     this.title.caption = `Dataset Details for ${this.dataset_id}`;
     this.title.label = this.name;

--- a/jupyterlab_bigquery/src/components/details_panel/service/list_dataset_details.ts
+++ b/jupyterlab_bigquery/src/components/details_panel/service/list_dataset_details.ts
@@ -5,7 +5,7 @@ export interface DatasetDetailsObject {
   id: string;
   display_name: string;
   description: string;
-  labels: string;
+  labels: string[];
   date_created: string;
   default_expiration: string;
   location: string;

--- a/jupyterlab_bigquery/src/components/details_panel/service/list_table_details.ts
+++ b/jupyterlab_bigquery/src/components/details_panel/service/list_table_details.ts
@@ -5,9 +5,9 @@ export interface TableDetailsObject {
   id: string;
   display_name: string;
   description: string;
-  labels: string;
+  labels: string[];
   date_created: string;
-  expires: string;
+  expiration: string;
   location: string;
   last_modified: string;
   project: string;

--- a/jupyterlab_bigquery/src/components/details_panel/table_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_panel.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 
-import { TableDetailsService } from './service/list_table_details';
+import {
+  TableDetailsService,
+  TableDetails,
+} from './service/list_table_details';
 
 interface Props {
   tableDetailsService: TableDetailsService;
@@ -11,8 +14,7 @@ interface Props {
 interface State {
   hasLoaded: boolean;
   isLoading: boolean;
-  // TODO(cxjia): type these details
-  details: any;
+  details: TableDetails;
 }
 
 export default class TableDetailsPanel extends React.Component<Props, State> {
@@ -21,7 +23,7 @@ export default class TableDetailsPanel extends React.Component<Props, State> {
     this.state = {
       hasLoaded: false,
       isLoading: false,
-      details: { details: {} },
+      details: { details: {} } as TableDetails,
     };
   }
 
@@ -42,16 +44,14 @@ export default class TableDetailsPanel extends React.Component<Props, State> {
   }
 
   private async getDetails() {
-    console.log('starting getDetails');
     try {
       this.setState({ isLoading: true });
       const details = await this.props.tableDetailsService.listTableDetails(
         this.props.table_id
       );
       this.setState({ hasLoaded: true, details });
-      console.log('Details: ', this.state.details);
     } catch (err) {
-      console.warn('Error retrieving dataset details', err);
+      console.warn('Error retrieving table details', err);
     } finally {
       this.setState({ isLoading: false });
     }

--- a/jupyterlab_bigquery/src/components/details_panel/table_details_widget.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_widget.tsx
@@ -16,7 +16,6 @@ export class TableDetailsWidget extends ReactWidget {
     private readonly name: string
   ) {
     super();
-    console.log('dataset id: ', this.dataset_id);
     this.title.iconClass = 'jp-Icon jp-Icon-20 jp-BigQueryIcon';
     this.title.caption = `Dataset Details for ${this.dataset_id}`;
     this.title.label = this.name;

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
@@ -118,7 +118,7 @@ function ListItem(props) {
         <div className={localStyles.icon} onClick={() => handleExpand()}>
           {getIconForWord(props.subfields)}
         </div>
-        <div className={localStyles.details} onClick={props.openDetails}>
+        <div className={localStyles.details} onDoubleClick={props.openDetails}>
           <a className="{css.link}" href="#">
             {props.name}
           </a>
@@ -154,7 +154,6 @@ export class ListDatasetItem extends React.Component<DatasetProps, State> {
           name={dataset.name}
           subfields={dataset.tables}
           openDetails={() => {
-            console.log('opening dataset details');
             const service = new DatasetDetailsService();
             const widgetType = DatasetDetailsWidget;
             context.manager.launchWidgetForId(
@@ -191,7 +190,6 @@ export class ListTableItem extends React.Component<TableProps, State> {
           name={table.name}
           subfields={null}
           openDetails={() => {
-            console.log('opening table details');
             const service = new TableDetailsService();
             const widgetType = TableDetailsWidget;
             context.manager.launchWidgetForId(


### PR DESCRIPTION
As part of cleanup of initial commit for the BigQuery extension:

- removes console.log statements
- adds correct typing for dataset and table details
- requires double click rather than click to open details

Addresses this [task](https://b.corp.google.com/issues/159993668).