### PR TITLE
[BigQuery] Table schema formatting changes

### DIFF
--- a/jupyterlab_bigquery/jupyterlab_bigquery/handlers.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/handlers.py
@@ -87,6 +87,13 @@ def get_dataset_details(client, dataset_id):
       }
   }
 
+def get_schema(schema):
+    return [{
+        'name': field.name,
+        'type': field.field_type,
+        'description': field.description,
+        'mode': field.mode
+    } for field in schema]
 
 def get_table_details(client, table_id):
   table = client.get_table(table_id)
@@ -105,7 +112,7 @@ def get_table_details(client, table_id):
           'link': table.self_link,
           'num_rows': table.num_rows,
           'num_bytes': table.num_bytes,
-          'schema': str(table.schema)
+          'schema': get_schema(table.schema)
       }
   }
 

--- a/jupyterlab_bigquery/src/components/details_panel/service/list_table_details.ts
+++ b/jupyterlab_bigquery/src/components/details_panel/service/list_table_details.ts
@@ -15,7 +15,14 @@ export interface TableDetailsObject {
   link: string;
   num_rows: number;
   num_bytes: number;
-  schema: string;
+  schema: Field[];
+}
+
+interface Field {
+  name: string;
+  type: string;
+  mode: string;
+  description: string;
 }
 
 export interface TableDetails {

--- a/jupyterlab_bigquery/src/components/details_panel/table_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_panel.tsx
@@ -95,7 +95,19 @@ export default class TableDetailsPanel extends React.Component<Props, State> {
             Data location: {details.location ? details.location : 'None'}
           </div>
           <br />
-          <div>Schema: {details.schema ? details.schema : 'None'}</div>
+          <div>
+            Schema:{' '}
+            {details.schema
+              ? details.schema.map((field, index) => {
+                  return (
+                    <div key={index}>
+                      {field.name} {field.type} {field.mode}{' '}
+                      {field.description ?? ''}
+                    </div>
+                  );
+                })
+              : 'None'}
+          </div>
         </div>
       );
     }


### PR DESCRIPTION
Adds more information for table schema (mode and description) and shows it in a more readable way. This is an intermediate step - a future PR will add further styling.