### PR TITLE
[HardwareConfiguration] Added workflow to display utilization charts when widget is clicked

### DIFF
--- a/jupyterlab_gcedetails/src/__snapshots__/details_widget.spec.tsx.snap
+++ b/jupyterlab_gcedetails/src/__snapshots__/details_widget.spec.tsx.snap
@@ -9,6 +9,25 @@ exports[`VmDetails Renders with details: Details 1`] = `
     onClick={[Function]}
     title="Show all details"
   />
+  <WidgetPopup>
+    <ResourceUtilizationCharts
+      detailsServer={
+        Object {
+          "getUtilizationData": [MockFunction] {
+            "calls": Array [
+              Array [],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": Promise {},
+              },
+            ],
+          },
+        }
+      }
+    />
+  </WidgetPopup>
   <span
     className="interactiveHover_feuq7k1"
   >
@@ -42,6 +61,25 @@ exports[`VmDetails Renders with details: Retrieving 1`] = `
     onClick={[Function]}
     title="Show all details"
   />
+  <WidgetPopup>
+    <ResourceUtilizationCharts
+      detailsServer={
+        Object {
+          "getUtilizationData": [MockFunction] {
+            "calls": Array [
+              Array [],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": Promise {},
+              },
+            ],
+          },
+        }
+      }
+    />
+  </WidgetPopup>
   <span
     className="interactiveHover_feuq7k1"
   >
@@ -59,6 +97,25 @@ exports[`VmDetails Renders with error: Received Error 1`] = `
     onClick={[Function]}
     title="Show all details"
   />
+  <WidgetPopup>
+    <ResourceUtilizationCharts
+      detailsServer={
+        Object {
+          "getUtilizationData": [MockFunction] {
+            "calls": Array [
+              Array [],
+            ],
+            "results": Array [
+              Object {
+                "type": "throw",
+                "value": [Error],
+              },
+            ],
+          },
+        }
+      }
+    />
+  </WidgetPopup>
   <span
     className="interactiveHover_feuq7k1"
   >

--- a/jupyterlab_gcedetails/src/components/chart_wrapper.tsx
+++ b/jupyterlab_gcedetails/src/components/chart_wrapper.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { stylesheet } from 'typestyle';
 import { AreaChart, Area, Tooltip, CartesianGrid, YAxis } from 'recharts';
 
 interface ChartProps {
@@ -13,6 +14,13 @@ interface ChartProps {
   yAxisProps: {};
 }
 
+const STYLES = stylesheet({
+  chartContainer: {
+    paddingBottom: '5px',
+    paddingTop: '5px',
+  },
+});
+
 export function AreaChartWrapper(props: ChartProps) {
   const {
     data,
@@ -25,7 +33,7 @@ export function AreaChartWrapper(props: ChartProps) {
     yAxisProps,
   } = props;
   return (
-    <span>
+    <div className={STYLES.chartContainer}>
       <h1 className={titleClass}>{title}</h1>
       <AreaChart {...areaChartProps} data={data}>
         <Area {...areaProps} dataKey={dataKey} />
@@ -33,6 +41,6 @@ export function AreaChartWrapper(props: ChartProps) {
         <CartesianGrid {...cartesianGridProps} />
         <YAxis {...yAxisProps} />
       </AreaChart>
-    </span>
+    </div>
   );
 }

--- a/jupyterlab_gcedetails/src/components/resource_utilization_charts.tsx
+++ b/jupyterlab_gcedetails/src/components/resource_utilization_charts.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { stylesheet } from 'typestyle';
 import { ServerWrapper } from './server_wrapper';
 import { AreaChartWrapper } from './chart_wrapper';
-import { Utilization, STYLES } from '../data';
+import { Utilization } from '../data';
 
 const AREA_CHART_BLUE = {
   stroke: '#15B2D3',
@@ -36,6 +37,16 @@ interface State {
   receivedError: boolean;
 }
 
+const STYLES = stylesheet({
+  chartTitleSmall: {
+    fontSize: '15px',
+    marginLeft: '20px',
+  },
+  utilizationChartsContainer: {
+      padding: '10px 20px 20px 0px',
+  },
+});
+
 export class ResourceUtilizationCharts extends React.Component<Props, State> {
   private refreshInterval: number;
   private readonly NUM_DATA_POINTS = 20;
@@ -64,7 +75,7 @@ export class ResourceUtilizationCharts extends React.Component<Props, State> {
 
   render() {
     return (
-      <span>
+      <div className={STYLES.utilizationChartsContainer}>
         {this.state.receivedError ? (
           'Unable to retrieve GCE VM details, please check your server logs'
         ) : (
@@ -87,7 +98,7 @@ export class ResourceUtilizationCharts extends React.Component<Props, State> {
             />
           </span>
         )}
-      </span>
+      </div>
     );
   }
 

--- a/jupyterlab_gcedetails/src/components/widget_popup.tsx
+++ b/jupyterlab_gcedetails/src/components/widget_popup.tsx
@@ -69,7 +69,9 @@ export class WidgetPopup extends React.Component<Props, State> {
         >
           {({ TransitionProps }) => (
             <Fade {...TransitionProps} timeout={350}>
-              <Paper>{this.props.children}</Paper>
+              <Paper elevation={5}>
+                {this.props.children}
+              </Paper>
             </Fade>
           )}
         </Popper>

--- a/jupyterlab_gcedetails/src/data.ts
+++ b/jupyterlab_gcedetails/src/data.ts
@@ -105,7 +105,7 @@ export const REFRESHABLE_MAPPED_ATTRIBUTES = [
 
 MAPPED_ATTRIBUTES.push(...REFRESHABLE_MAPPED_ATTRIBUTES);
 
-/* Class names applied to the component. Exported for test selectors. */
+/* Class names applied to the component. */
 export const STYLES = stylesheet({
   container: {
     color: 'var(--jp-ui-font-color1)',
@@ -146,9 +146,5 @@ export const STYLES = stylesheet({
   listRow: {
     display: 'table-row',
     boxShadow: 'inset 0 -1px 0 0 var(--jp-border-color0)',
-  },
-  chartTitleSmall: {
-    fontSize: '20px',
-    marginLeft: '20px',
   },
 });

--- a/jupyterlab_gcedetails/src/details_widget.tsx
+++ b/jupyterlab_gcedetails/src/details_widget.tsx
@@ -25,6 +25,8 @@ import {
 } from './data';
 import { DetailsDialogBody } from './components/details_dialog_body';
 import { ServerWrapper } from './components/server_wrapper';
+import { ResourceUtilizationCharts } from './components/resource_utilization_charts';
+import { WidgetPopup } from './components/widget_popup';
 
 interface Props {
   detailsServer: ServerWrapper;
@@ -66,6 +68,7 @@ export class VmDetails extends React.Component<Props, State> {
 
   render() {
     const { details, receivedError } = this.state;
+    const { detailsServer } = this.props;
     const noDetailsMessage = receivedError
       ? 'Error retrieving VM Details'
       : 'Retrieving VM Details...';
@@ -81,6 +84,9 @@ export class VmDetails extends React.Component<Props, State> {
           title="Show all details"
           onClick={() => this.showDialog()}
         ></span>
+        <WidgetPopup>
+          <ResourceUtilizationCharts detailsServer={detailsServer}/>
+        </WidgetPopup>
         <span className={classes(STYLES.interactiveHover)}>
           {details ? this.getDisplayedDetails(details) : noDetailsMessage}
         </span>


### PR DESCRIPTION
A new icon should appear in the widget in the status bar, clicking on which displays a popup containing charts visualizing the memory and cpu usage:

![Screenshot 2020-07-01 at 2 23 02 PM](https://user-images.githubusercontent.com/28398459/86279236-b2af8000-bba7-11ea-909c-1c2f7f04eb5a.png)

Additionally, moved styling constants only used in certain files to those files, rather than exporting them from the data file.