### PR TITLE
[jupyter-gcs-contents-manager] Improve error message for creating a file in the virtual top-level directory

### DIFF
--- a/jupyter-gcs-contents-manager/gcs_contents_manager.py
+++ b/jupyter-gcs-contents-manager/gcs_contents_manager.py
@@ -548,7 +548,7 @@ class CombinedContentsManager(ContentsManager):
       if path == path_prefix or path.startswith(path_prefix + '/'):
         relative_path = path[len(path_prefix):]
         return self._content_managers[path_prefix], relative_path, path_prefix
-    return None, '', path
+    return None, path, ''
 
   def is_hidden(self, path):
     try:
@@ -645,7 +645,7 @@ class CombinedContentsManager(ContentsManager):
       self.run_pre_save_hook(model=model, path=path)
 
       cm, relative_path, path_prefix = self._content_manager_for_path(path)
-      if relative_path in ['', '/']:
+      if (relative_path in ['', '/']) or (path_prefix in ['', '/']):
         raise HTTPError(403, 'The top-level directory contents are read-only')
       if not cm:
         raise HTTPError(404, 'No content manager defined for "{}"'.format(path))
@@ -668,7 +668,7 @@ class CombinedContentsManager(ContentsManager):
       raise HTTPError(403, 'The top-level directory is read-only')
     try:
       cm, relative_path, path_prefix = self._content_manager_for_path(path)
-      if relative_path in ['', '/']:
+      if (relative_path in ['', '/']) or (path_prefix in ['', '/']):
         raise HTTPError(403, 'The top-level directory contents are read-only')
       if not cm:
         raise HTTPError(404, 'No content manager defined for "{}"'.format(path))

--- a/jupyter-gcs-contents-manager/gcs_contents_manager.py
+++ b/jupyter-gcs-contents-manager/gcs_contents_manager.py
@@ -548,6 +548,9 @@ class CombinedContentsManager(ContentsManager):
       if path == path_prefix or path.startswith(path_prefix + '/'):
         relative_path = path[len(path_prefix):]
         return self._content_managers[path_prefix], relative_path, path_prefix
+    if '/' in path:
+        path_parts = path.split('/', 1)
+        return None, path_parts[1], path_parts[0]
     return None, path, ''
 
   def is_hidden(self, path):
@@ -696,14 +699,14 @@ class CombinedContentsManager(ContentsManager):
     if (old_path in ['', '/']) or (new_path in ['', '/']):
       raise HTTPError(403, 'The top-level directory is read-only')
     try:
-      old_cm, old_relative_path, _ = self._content_manager_for_path(old_path)
-      if old_relative_path in ['', '/']:
+      old_cm, old_relative_path, old_prefix = self._content_manager_for_path(old_path)
+      if (old_relative_path in ['', '/']) or (old_prefix in ['', '/']) :
         raise HTTPError(403, 'The top-level directory contents are read-only')
       if not old_cm:
         raise HTTPError(404, 'No content manager defined for "{}"'.format(old_path))
 
-      new_cm, new_relative_path, _ = self._content_manager_for_path(new_path)
-      if new_relative_path in ['', '/']:
+      new_cm, new_relative_path, new_prefix = self._content_manager_for_path(new_path)
+      if (new_relative_path in ['', '/']) or (new_prefix in ['', '/']) :
         raise HTTPError(403, 'The top-level directory contents are read-only')
       if not new_cm:
         raise HTTPError(404, 'No content manager defined for "{}"'.format(new_path))


### PR DESCRIPTION
This change fixes a usability issue in the error message returned when a user of the CombinedContentsManager tries to save a file to the virtual, top-level directory.

Previously, that would result in a 404 error due to the contents manager not being able to find a nested contents manager for the top-level.

With this new change, it will return a 403 error saying the top-level is read-only