### PR TITLE
[Release] Add upload steps to collect artifacts from pushes

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,6 +1,6 @@
-name: Presubmit
+name: Postpush
 on:
-  pull_request:
+  push:
     branches:
       - master
 jobs:
@@ -30,3 +30,18 @@ jobs:
       - name: Run Tests
         run: source $(pipenv --venv)/bin/activate &&
           scripts/run_all_tests.sh
+      - name: Upload Python Shared
+        uses: actions/upload-artifact@v2
+        with:
+          name: gcp_jupyterlab_shared_server_${{ github.sha }}
+          path: shared/dist/*.tar.gz
+      - name: Upload TS Shared
+        uses: actions/upload-artifact@v2
+        with:
+          name: gcp_jupyterlab_shared_client_${{ github.sha }}
+          path: shared/*.tgz
+      - name: Upload Extensions
+        uses: actions/upload-artifact@v2
+        with:
+          name: jupyterlab_extensions_${{ github.sha }}
+          path: jupyter*/dist/*.tar.gz


### PR DESCRIPTION
Addresses points in #81

This change will introduce a new **Postpush** workflow that runs when a new change is pushed to `master`.

When this action runs, three (3) artifacts will be produced which contain artifacts that can be uploaded to a release.

1. `gcp_jupyterlab_shared_server_<commit sha>` contains the shared Python package from the `shared` subfolder
1. `gcp_jupyterlab_shared_client_<commit sha>` contains the shared TS package from the `shared` subfolder
1. `jupyterlab_extensions_<commit sha>` is a zip folder comprised of the Python package from each `jupyter*` subfolder.

See https://github.com/prodonjs/jupyter-gcs-contents-manager/actions/runs/168631713 for an example