### PR TITLE
[BigQuery] Fix dataset/table expiration and empty schema display

### DIFF
--- a/jupyterlab_bigquery/src/components/details_panel/dataset_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/dataset_details_panel.tsx
@@ -44,6 +44,11 @@ export default class DatasetDetailsPanel extends React.Component<Props, State> {
     }
   }
 
+  formatMs(ms) {
+    const days = ms / 86400000;
+    return `${days} day${days > 1 ? 's' : ''} 0 hr`;
+  }
+
   private async getDetails() {
     try {
       this.setState({ isLoading: true });
@@ -58,7 +63,7 @@ export default class DatasetDetailsPanel extends React.Component<Props, State> {
         {
           name: 'Default table expiration',
           value: detailsObj.default_expiration
-            ? detailsObj.default_expiration
+            ? this.formatMs(detailsObj.default_expiration)
             : 'Never',
         },
         { name: 'Last modified', value: detailsObj.last_modified },

--- a/jupyterlab_bigquery/src/components/details_panel/dataset_details_widget.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/dataset_details_widget.tsx
@@ -1,5 +1,4 @@
-import { ReactWidget, UseSignal } from '@jupyterlab/apputils';
-import { Signal } from '@phosphor/signaling';
+import { ReactWidget } from '@jupyterlab/apputils';
 import * as React from 'react';
 
 import { DatasetDetailsService } from './service/list_dataset_details';
@@ -8,7 +7,6 @@ import DatasetDetailsPanel from './dataset_details_panel';
 /** Widget to be registered in the main panel. */
 export class DatasetDetailsWidget extends ReactWidget {
   id = 'dataset-details-widget';
-  private visibleSignal = new Signal<DatasetDetailsWidget, boolean>(this);
 
   constructor(
     private readonly service: DatasetDetailsService,
@@ -22,27 +20,13 @@ export class DatasetDetailsWidget extends ReactWidget {
     this.title.closable = true;
   }
 
-  onAfterHide() {
-    this.visibleSignal.emit(false);
-  }
-
-  onAfterShow() {
-    this.visibleSignal.emit(true);
-  }
-
   render() {
     return (
-      <UseSignal signal={this.visibleSignal}>
-        {(_, isVisible) => {
-          return (
-            <DatasetDetailsPanel
-              isVisible={isVisible}
-              dataset_id={this.dataset_id}
-              datasetDetailsService={this.service}
-            />
-          );
-        }}
-      </UseSignal>
+      <DatasetDetailsPanel
+        isVisible={this.isVisible}
+        dataset_id={this.dataset_id}
+        datasetDetailsService={this.service}
+      />
     );
   }
 }

--- a/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
@@ -86,6 +86,9 @@ interface Props {
 
 export const DetailsPanel: React.SFC<Props> = props => {
   const { details, rows, detailsType } = props;
+  if (details.schema) {
+    console.log('schema: ', details.schema);
+  }
   return (
     <div className={localStyles.panel}>
       <div className={localStyles.detailsBody}>
@@ -111,7 +114,9 @@ export const DetailsPanel: React.SFC<Props> = props => {
           </Grid>
 
           <Grid item xs={12}>
-            <div className={localStyles.title}>Dataset info</div>
+            <div className={localStyles.title}>
+              {detailsType === 'table' ? 'Table' : 'Dataset'} info
+            </div>
             {rows.map((row, index) => (
               <div
                 key={index}
@@ -135,7 +140,7 @@ export const DetailsPanel: React.SFC<Props> = props => {
 
         {detailsType === 'table' && (
           <div className={localStyles.scrollable}>
-            {details.schema ? (
+            {details.schema && details.schema.length > 0 ? (
               <Table
                 size="small"
                 style={{ width: 'auto', tableLayout: 'auto' }}

--- a/jupyterlab_bigquery/src/components/details_panel/service/list_dataset_details.ts
+++ b/jupyterlab_bigquery/src/components/details_panel/service/list_dataset_details.ts
@@ -7,7 +7,7 @@ export interface DatasetDetailsObject {
   description: string;
   labels: string[];
   date_created: string;
-  default_expiration: string;
+  default_expiration: number;
   location: string;
   last_modified: string;
   project: string;

--- a/jupyterlab_bigquery/src/components/details_panel/service/list_table_details.ts
+++ b/jupyterlab_bigquery/src/components/details_panel/service/list_table_details.ts
@@ -7,7 +7,7 @@ export interface TableDetailsObject {
   description: string;
   labels: string[];
   date_created: string;
-  expiration: string;
+  expires: string;
   location: string;
   last_modified: string;
   project: string;

--- a/jupyterlab_bigquery/src/components/details_panel/table_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_panel.tsx
@@ -74,7 +74,7 @@ export default class TableDetailsPanel extends React.Component<Props, State> {
         { name: 'Created', value: detailsObj.date_created },
         {
           name: 'Table expiration',
-          value: detailsObj.expiration ? detailsObj.expiration : 'Never',
+          value: detailsObj.expires ? detailsObj.expires : 'Never',
         },
         {
           name: 'Last modified',

--- a/jupyterlab_bigquery/src/components/details_panel/table_details_widget.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_widget.tsx
@@ -1,5 +1,4 @@
-import { ReactWidget, UseSignal } from '@jupyterlab/apputils';
-import { Signal } from '@phosphor/signaling';
+import { ReactWidget } from '@jupyterlab/apputils';
 import * as React from 'react';
 
 import { TableDetailsService } from './service/list_table_details';
@@ -8,7 +7,6 @@ import TableDetailsTabs from './table_details_tabs';
 /** Widget to be registered in the main panel. */
 export class TableDetailsWidget extends ReactWidget {
   id = 'table-details-widget';
-  private visibleSignal = new Signal<TableDetailsWidget, boolean>(this);
 
   constructor(
     private readonly service: TableDetailsService,
@@ -22,28 +20,14 @@ export class TableDetailsWidget extends ReactWidget {
     this.title.closable = true;
   }
 
-  onAfterHide() {
-    this.visibleSignal.emit(false);
-  }
-
-  onAfterShow() {
-    this.visibleSignal.emit(true);
-  }
-
   render() {
     return (
-      <UseSignal signal={this.visibleSignal}>
-        {(_, isVisible) => {
-          return (
-            <TableDetailsTabs
-              isVisible={isVisible}
-              table_id={this.table_id}
-              table_name={this.name}
-              tableDetailsService={this.service}
-            />
-          );
-        }}
-      </UseSignal>
+      <TableDetailsTabs
+        isVisible={this.isVisible}
+        table_id={this.table_id}
+        table_name={this.name}
+        tableDetailsService={this.service}
+      />
     );
   }
 }

--- a/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab_widget.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab_widget.tsx
@@ -1,5 +1,3 @@
-import { UseSignal } from '@jupyterlab/apputils';
-import { Signal } from '@phosphor/signaling';
 import QueryEditorTab from './query_editor_tab';
 import * as React from 'react';
 import { stylesheet } from 'typestyle';
@@ -14,7 +12,6 @@ const localStyles = stylesheet({
 
 export class QueryEditorTabWidget extends ReduxReactWidget {
   id = 'query-editor-tab';
-  private visibleSignal = new Signal<QueryEditorTabWidget, boolean>(this);
 
   constructor() {
     super();
@@ -22,25 +19,11 @@ export class QueryEditorTabWidget extends ReduxReactWidget {
     this.title.closable = true;
   }
 
-  onAfterHide() {
-    this.visibleSignal.emit(false);
-  }
-
-  onAfterShow() {
-    this.visibleSignal.emit(true);
-  }
-
   renderReact() {
     return (
-      <UseSignal signal={this.visibleSignal}>
-        {(_, isVisible) => {
-          return (
-            <div className={localStyles.panel}>
-              <QueryEditorTab isVisible={isVisible} />
-            </div>
-          );
-        }}
-      </UseSignal>
+      <div className={localStyles.panel}>
+        <QueryEditorTab isVisible={this.isVisible} />
+      </div>
     );
   }
 }


### PR DESCRIPTION
Small fixes:

- Corrects formatting for dataset default expiration and table expiration (previously showed dataset expiration as straight milliseconds and  table expiration as None)
- Shows empty schema message (previously would show empty table with headers)
- Removes unnecessary signals in `dataset_details_widget`, `table_details_widget`, and `query_editor_tab_widget`