### PR TITLE
[BigQuery] Make entire details panel scrollable

### DIFF
--- a/jupyterlab_bigquery/src/components/details_panel/dataset_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/dataset_details_panel.tsx
@@ -5,7 +5,24 @@ import {
   DatasetDetails,
 } from './service/list_dataset_details';
 import LoadingPanel from '../loading_panel';
-import { DetailsPanel, localStyles } from './details_panel';
+import { DetailsPanel } from './details_panel';
+import { stylesheet } from 'typestyle';
+
+const localStyles = stylesheet({
+  body: {
+    marginBottom: '24px',
+    marginRight: '24px',
+    marginLeft: '24px',
+    height: '100%',
+    overflowY: 'auto',
+  },
+  header: {
+    borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)',
+    fontSize: '18px',
+    margin: 0,
+    padding: '8px 12px 8px 24px',
+  },
+});
 
 interface Props {
   datasetDetailsService: DatasetDetailsService;
@@ -86,17 +103,11 @@ export default class DatasetDetailsPanel extends React.Component<Props, State> {
       return <LoadingPanel />;
     } else {
       return (
-        <div>
+        <div style={{ height: '100%' }}>
           <header className={localStyles.header}>
             {this.props.dataset_id}
           </header>
-          <div
-            style={{
-              marginBottom: '24px',
-              marginRight: '24px',
-              marginLeft: '24px',
-            }}
-          >
+          <div className={localStyles.body}>
             <DetailsPanel
               details={this.state.details.details}
               rows={this.state.rows}

--- a/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
@@ -32,10 +32,6 @@ export const localStyles = stylesheet({
   },
   detailsBody: {
     fontSize: '13px',
-    flex: 1,
-    minHeight: 0,
-    display: 'flex',
-    flexDirection: 'column',
     marginTop: '24px',
   },
   labelContainer: {
@@ -51,11 +47,6 @@ export const localStyles = stylesheet({
   row: {
     display: 'flex',
     padding: '6px',
-  },
-  scrollable: {
-    flex: 1,
-    minHeight: 0,
-    overflow: 'auto',
   },
 });
 
@@ -86,9 +77,7 @@ interface Props {
 
 export const DetailsPanel: React.SFC<Props> = props => {
   const { details, rows, detailsType } = props;
-  if (details.schema) {
-    console.log('schema: ', details.schema);
-  }
+
   return (
     <div className={localStyles.panel}>
       <div className={localStyles.detailsBody}>
@@ -139,7 +128,7 @@ export const DetailsPanel: React.SFC<Props> = props => {
         )}
 
         {detailsType === 'table' && (
-          <div className={localStyles.scrollable}>
+          <div>
             {details.schema && details.schema.length > 0 ? (
               <Table
                 size="small"

--- a/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
@@ -106,6 +106,8 @@ function TabPanel(props: TabPanelProps) {
         minHeight: 0,
         flexDirection: 'column',
         display: value !== index ? 'none' : 'flex',
+        overflowX: value === TabInds.preview ? 'auto' : 'hidden',
+        overflowY: 'auto',
       }}
     >
       {children}


### PR DESCRIPTION
In a [previous PR](https://github.com/GoogleCloudPlatform/jupyter-extensions/pull/99) I made just the schema scrollable, but since it is currently on the same panel as the details, the entire panel should be scrollable to account for smaller screens.