### PR TITLE
[BigQuery] Create snackbar for errors

### DIFF
--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
@@ -28,6 +28,7 @@ import { DatasetDetailsService } from '../details_panel/service/list_dataset_det
 import { TableDetailsWidget } from '../details_panel/table_details_widget';
 import { TableDetailsService } from '../details_panel/service/list_table_details';
 import { updateProject, updateDataset } from '../../reducers/dataTreeSlice';
+import { openSnackbar } from '../../reducers/snackbarSlice';
 
 import '../../../style/index.css';
 
@@ -75,6 +76,7 @@ interface ProjectProps {
   listDatasetsService: ListDatasetsService;
   listTablesService: ListTablesService;
   listModelsService: ListModelsService;
+  openSnackbar: any;
 }
 
 interface State {
@@ -259,7 +261,7 @@ export function BuildTree(project, context, expandProject, expandDataset) {
     <TreeItem
       nodeId={project.id}
       label={project.name}
-      onIconClick={() => expandProject(project)}
+      onIconClick={expandProject(project)}
     >
       {Array.isArray(project.datasetIds) ? (
         project.datasetIds.map(datasetId => (
@@ -292,26 +294,10 @@ class ListProjectItem extends React.Component<ProjectProps, State> {
     super(props);
   }
 
-  render() {
-    const { dataTree, context } = this.props;
-    if (Array.isArray(dataTree.projectIds)) {
-      return dataTree.projectIds.map(projectId => (
-        <div key={projectId}>
-          {BuildTree(
-            dataTree.projects[projectId],
-            context,
-            this.expandProject,
-            this.expandDataset
-          )}
-        </div>
-      ));
-    } else {
-      return <LinearProgress />;
-    }
-  }
-
   expandProject = project => {
-    if (!Array.isArray(project.datasetIds)) {
+    if (project.error) {
+      this.handleOpenSnackbar(project.error);
+    } else if (!Array.isArray(project.datasetIds)) {
       this.getDatasets(project, this.props.listDatasetsService);
     }
   };
@@ -324,17 +310,21 @@ class ListProjectItem extends React.Component<ProjectProps, State> {
     try {
       await listDatasetsService.listDatasets(project).then((data: Project) => {
         if (data.datasetIds.length === 0) {
-          newProject['error'] =
-            'No datasets available. Check your permissions for this project.';
+          newProject[
+            'error'
+          ] = `No datasets available for ${project.name}. Check your permissions for this project.`;
         } else {
           newProject['datasets'] = data.datasets;
           newProject['datasetIds'] = data.datasetIds;
         }
       });
     } catch (err) {
-      console.warn('Error retrieving datasets', err);
-      newProject['error'] =
-        'No datasets available. Check your permissions for this project.';
+      const fullError = err.response.statusText;
+      console.warn('Error retrieving datasets: ', fullError);
+      const errorMessage =
+        fullError.split('datasets: ')[1] ||
+        'The project does not exist or does not have BigQuery enabled.';
+      newProject['error'] = `Error: ${errorMessage}`;
     } finally {
       this.props.updateProject(newProject);
     }
@@ -378,12 +368,38 @@ class ListProjectItem extends React.Component<ProjectProps, State> {
       console.warn('Error retrieving dataset children', err);
     }
   }
+
+  handleOpenSnackbar = error => {
+    this.props.openSnackbar(error);
+  };
+
+  render() {
+    const { dataTree, context } = this.props;
+    if (Array.isArray(dataTree.projectIds)) {
+      return dataTree.projectIds.map(projectId => (
+        <div key={projectId}>
+          {BuildTree(
+            dataTree.projects[projectId],
+            context,
+            this.expandProject,
+            this.expandDataset
+          )}
+        </div>
+      ));
+    } else {
+      return <LinearProgress />;
+    }
+  }
 }
 
 const mapStateToProps = state => {
   const dataTree = state.dataTree.data;
   return { dataTree };
 };
-const mapDispatchToProps = { updateProject, updateDataset };
+const mapDispatchToProps = {
+  updateProject,
+  updateDataset,
+  openSnackbar,
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(ListProjectItem);

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
@@ -1,4 +1,4 @@
-import { LinearProgress, Button, Switch } from '@material-ui/core';
+import { LinearProgress, Button, Switch, Portal } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import * as csstips from 'csstips';
 import * as React from 'react';
@@ -19,12 +19,14 @@ import { WidgetManager } from '../../utils/widgetManager/widget_manager';
 import ListSearchResults from './list_search_results';
 import { QueryEditorTabWidget } from '../query_editor/query_editor_tab/query_editor_tab_widget';
 import { updateDataTree, addProject } from '../../reducers/dataTreeSlice';
+import { SnackbarState } from '../../reducers/snackbarSlice';
 import {
   SearchProjectsService,
   SearchResult,
 } from '../list_items_panel/service/search_items';
 import { SearchBar } from './search_bar';
 import { DialogComponent } from 'gcp_jupyterlab_shared';
+import CustomSnackbar from './snackbar';
 
 interface Props {
   listProjectsService: ListProjectsService;
@@ -36,6 +38,7 @@ interface Props {
   updateDataTree: any;
   currentProject: string;
   addProject: any;
+  snackbar: SnackbarState;
 }
 
 export interface Context {
@@ -229,8 +232,12 @@ class ListItemsPanel extends React.Component<Props, State> {
       pinProjectDialogOpen,
       loadingPinnedProject,
     } = this.state;
+    const { snackbar } = this.props;
     return (
       <div className={localStyles.panel}>
+        <Portal>
+          <CustomSnackbar open={snackbar.open} message={snackbar.message} />
+        </Portal>
         <header className={localStyles.header}>
           BigQuery in Notebooks
           <Button
@@ -362,7 +369,8 @@ class ListItemsPanel extends React.Component<Props, State> {
 
 const mapStateToProps = state => {
   const currentProject = state.dataTree.data.projectIds[0];
-  return { currentProject };
+  const snackbar = state.snackbar;
+  return { currentProject, snackbar };
 };
 const mapDispatchToProps = {
   updateDataTree,

--- a/jupyterlab_bigquery/src/components/list_items_panel/snackbar.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/snackbar.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import CloseIcon from '@material-ui/icons/Close';
+import { Snackbar, IconButton } from '@material-ui/core';
+import { connect } from 'react-redux';
+import { closeSnackbar } from '../../reducers/snackbarSlice';
+
+interface Props {
+  open: boolean;
+  message: string;
+  closeSnackbar: any;
+}
+
+function CustomSnackbar(props: React.PropsWithChildren<Props>) {
+  const handleClose = (
+    event: React.SyntheticEvent | React.MouseEvent,
+    reason?: string
+  ) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    props.closeSnackbar();
+  };
+  return (
+    <Snackbar
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'right',
+      }}
+      open={props.open}
+      onClose={handleClose}
+      message={props.message}
+      action={
+        <React.Fragment>
+          {props.children}
+          <IconButton
+            size="small"
+            aria-label="close"
+            color="inherit"
+            onClick={handleClose}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </React.Fragment>
+      }
+    />
+  );
+}
+
+const mapDispatchToProps = {
+  closeSnackbar,
+};
+
+export default connect(null, mapDispatchToProps)(CustomSnackbar);

--- a/jupyterlab_bigquery/src/reducers/index.ts
+++ b/jupyterlab_bigquery/src/reducers/index.ts
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux';
 import queryEditorTabReducer from './queryEditorTabSlice';
 import dataTreeReducer from './dataTreeSlice';
+import snackbarReducer from './snackbarSlice';
 
 export default combineReducers({
   queryEditorTab: queryEditorTabReducer,
   dataTree: dataTreeReducer,
+  snackbar: snackbarReducer,
 });

--- a/jupyterlab_bigquery/src/reducers/snackbarSlice.ts
+++ b/jupyterlab_bigquery/src/reducers/snackbarSlice.ts
@@ -1,0 +1,31 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface SnackbarState {
+  open: boolean;
+  message: string;
+}
+
+const initialState: SnackbarState = {
+  open: false,
+  message: 'Error',
+};
+
+const snackbarSlice = createSlice({
+  name: 'snackbar',
+  initialState,
+  reducers: {
+    openSnackbar(state, action: PayloadAction<string>) {
+      const snackbarMessage = action.payload;
+      state.open = true;
+      state.message = snackbarMessage;
+    },
+    closeSnackbar(state) {
+      state.open = false;
+      state.message = initialState.message;
+    },
+  },
+});
+
+export const { openSnackbar, closeSnackbar } = snackbarSlice.actions;
+
+export default snackbarSlice.reducer;


### PR DESCRIPTION
Create snackbar to display error notifications, which can be called from anywhere in the extension using redux.
Use the snackbar to display errors when pinned projects have issues/permissions problems.