### PR TITLE
[Optimizer] update suggest trials for interval vizier team

### DIFF
--- a/jupyterlab_caip_optimizer/src/components/study_details.tsx
+++ b/jupyterlab_caip_optimizer/src/components/study_details.tsx
@@ -75,12 +75,12 @@ function formatParams(params: Types.ParameterSpec[]): FormattedParam[] {
         formattedParam['values'] = param['categoricalValueSpec'].values;
         break;
       case 'DOUBLE':
-        formattedParam['minValue'] = param['doubleValueSpec'].minValue;
-        formattedParam['maxValue'] = param['doubleValueSpec'].maxValue;
+        formattedParam['minValue'] = param['doubleValueSpec'].minValue ?? 0;
+        formattedParam['maxValue'] = param['doubleValueSpec'].maxValue ?? 0;
         break;
       case 'INTEGER':
-        formattedParam['minValue'] = param['integerValueSpec'].minValue;
-        formattedParam['maxValue'] = param['integerValueSpec'].maxValue;
+        formattedParam['minValue'] = param['integerValueSpec'].minValue ?? 0;
+        formattedParam['maxValue'] = param['integerValueSpec'].maxValue ?? 0;
         break;
     }
     return formattedParam;

--- a/jupyterlab_caip_optimizer/src/components/suggest_trials/add_measurement_dialog.tsx
+++ b/jupyterlab_caip_optimizer/src/components/suggest_trials/add_measurement_dialog.tsx
@@ -31,7 +31,7 @@ import { Loading } from './loading';
 import { prettifyTrial } from '../../service/optimizer';
 import { MetricsInputs } from './index';
 import { useDispatch } from 'react-redux';
-import { completeTrial } from '../../store/studies';
+import { completeTrial, addMeasurementTrial } from '../../store/studies';
 import {
   metricSpecsToMetrics,
   metricsToMeasurement,
@@ -57,6 +57,7 @@ export const AddMeasurementDialog: React.FC<Props> = ({
   const [metrics, setMetrics] = React.useState<MetricsInputs>(() =>
     metricSpecsToMetrics(studyConfig.metrics)
   );
+  const [finalMeasurement, setFinalMeasurement] = React.useState(true);
   const [infeasible, setInfeasible] = React.useState(false);
   const [infeasibleReason, setInfeasibleReason] = React.useState('');
 
@@ -80,7 +81,7 @@ export const AddMeasurementDialog: React.FC<Props> = ({
           },
         })
       );
-    } else {
+    } else if (finalMeasurement) {
       await dispatch(
         completeTrial({
           studyName,
@@ -88,6 +89,14 @@ export const AddMeasurementDialog: React.FC<Props> = ({
           details: {
             finalMeasurement: metricsToMeasurement(metrics),
           },
+        })
+      );
+    } else {
+      await dispatch(
+        addMeasurementTrial({
+          studyName,
+          trialName,
+          measurement: metricsToMeasurement(metrics),
         })
       );
     }
@@ -111,6 +120,18 @@ export const AddMeasurementDialog: React.FC<Props> = ({
       )}
       <DialogContent>
         <DialogContentText>Add evaluated trial data.</DialogContentText>
+        <FormControlLabel
+          control={
+            <Checkbox
+              data-testid="finalMeasurement"
+              checked={finalMeasurement}
+              onChange={event => setFinalMeasurement(event.target.checked)}
+              color="primary"
+              disabled={infeasible}
+            />
+          }
+          label="Final Measurement"
+        />
         <MetricInputs
           metricSpecs={studyConfig.metrics}
           value={metrics}

--- a/jupyterlab_caip_optimizer/src/components/suggest_trials/create_trial.tsx
+++ b/jupyterlab_caip_optimizer/src/components/suggest_trials/create_trial.tsx
@@ -234,7 +234,6 @@ export const CreateTrial: React.FC<Props> = ({
               checked={requested}
               onChange={event => setRequested(event.target.checked)}
               color="primary"
-              disabled={requested}
             />
           }
           label="Request Trial"

--- a/jupyterlab_caip_optimizer/src/components/suggest_trials/create_trial.tsx
+++ b/jupyterlab_caip_optimizer/src/components/suggest_trials/create_trial.tsx
@@ -12,6 +12,8 @@ import {
   Select,
   MenuItem,
   Typography,
+  FormControlLabel,
+  Checkbox,
 } from '@material-ui/core';
 import { prettifyStudyName } from '../../service/optimizer';
 import { Loading } from './loading';
@@ -26,7 +28,7 @@ import {
   inputValuesToParameterList,
   metricsToMeasurement,
 } from './utils';
-import { StudyConfig, ParameterSpec, State } from '../../types';
+import { StudyConfig, ParameterSpec, TrialState } from '../../types';
 import { ErrorState } from '../../utils/use_error_state';
 import {
   useErrorStateMap,
@@ -160,6 +162,7 @@ export const CreateTrial: React.FC<Props> = ({
   const [metrics, setMetrics] = React.useState<MetricsInputs>(() =>
     metricSpecsToMetrics(studyConfig.metrics)
   );
+  const [requested, setRequested] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
   // Creates parameter default values of '' and setups input error handling
   // using the custom hook
@@ -177,20 +180,36 @@ export const CreateTrial: React.FC<Props> = ({
 
   const handleSubmit = async () => {
     setLoading(true);
-    dispatch(
-      createTrial({
-        studyName,
-        trial: {
-          state: State.COMPLETED,
-          parameters: inputValuesToParameterList(
-            errorStateMapToValueObject(map),
-            studyConfig.parameters
-          ),
-          finalMeasurement: metricsToMeasurement(metrics),
-          measurements: [],
-        },
-      })
-    );
+    if (requested) {
+      await dispatch(
+        createTrial({
+          studyName,
+          trial: {
+            state: TrialState.REQUESTED,
+            parameters: inputValuesToParameterList(
+              errorStateMapToValueObject(map),
+              studyConfig.parameters
+            ),
+            measurements: [],
+          },
+        })
+      );
+    } else {
+      await dispatch(
+        createTrial({
+          studyName,
+          trial: {
+            state: TrialState.COMPLETED,
+            parameters: inputValuesToParameterList(
+              errorStateMapToValueObject(map),
+              studyConfig.parameters
+            ),
+            finalMeasurement: metricsToMeasurement(metrics),
+            measurements: [],
+          },
+        })
+      );
+    }
     setLoading(false);
     setMetrics(clearMetrics(metrics));
     onClose();
@@ -208,15 +227,31 @@ export const CreateTrial: React.FC<Props> = ({
       </DialogTitle>
       <DialogContent>
         <DialogContentText>Add custom trial data.</DialogContentText>
+        <FormControlLabel
+          control={
+            <Checkbox
+              data-testid="requestedTrial"
+              checked={requested}
+              onChange={event => setRequested(event.target.checked)}
+              color="primary"
+              disabled={requested}
+            />
+          }
+          label="Request Trial"
+        />
         {/* Parameter inputs */}
         <Typography component="h3">Parameters</Typography>
         {parameterSpecToInputs(map, setInput, studyConfig.parameters)}
-        <Typography component="h3">Metrics</Typography>
-        <MetricInputs
-          metricSpecs={studyConfig.metrics}
-          value={metrics}
-          onChange={setMetrics}
-        />
+        {!requested && (
+          <>
+            <Typography component="h3">Metrics</Typography>
+            <MetricInputs
+              metricSpecs={studyConfig.metrics}
+              value={metrics}
+              onChange={setMetrics}
+            />
+          </>
+        )}
       </DialogContent>
       <DialogActions>
         <Button

--- a/jupyterlab_caip_optimizer/src/components/suggest_trials/index.spec.tsx
+++ b/jupyterlab_caip_optimizer/src/components/suggest_trials/index.spec.tsx
@@ -412,7 +412,7 @@ describe('Suggest Trials Page', () => {
     });
   });
 
-  describe('Add custom measurement', () => {
+  describe('add custom measurement', () => {
     let createTrial: jest.Mock;
     // open dialog
     beforeEach(async () => {
@@ -428,7 +428,7 @@ describe('Suggest Trials Page', () => {
       await waitFor(() => screen.getByTestId('createTrialDialog'));
     });
 
-    it('adds parameter and final measurement value and submits them', async () => {
+    it('creates a custom trial with parameters and metrics filled out', async () => {
       const parameterInputs = screen.getAllByTestId('selectionInput');
       expect(parameterInputs).toHaveLength(2);
 
@@ -504,6 +504,59 @@ describe('Suggest Trials Page', () => {
       await waitForElementToBeRemoved(() =>
         screen.queryByTestId('createTrialDialog')
       );
+    });
+
+    it('creates a requested trial', async () => {
+      const parameterInputs = screen.getAllByTestId('selectionInput');
+      expect(parameterInputs).toHaveLength(2);
+
+      const metricInputs = screen.getAllByTestId('metricInput');
+      expect(metricInputs).toHaveLength(2);
+
+      // enable requested
+      userEvent.click(screen.getByTestId('requestedTrial'));
+
+      // parameters
+
+      // categorical type (param-categorical)
+      // open selection panel
+      userEvent.click(parameterInputs[0]);
+      await waitFor(() => screen.getByTestId('categorical-type-menuItem'));
+      // select option
+      userEvent.click(screen.getByTestId('categorical-type-menuItem'));
+
+      // discrete type (param-discrete)
+      // open selection panel
+      userEvent.click(parameterInputs[1]);
+      await waitFor(() => screen.getByTestId('556-menuItem'));
+      // select option
+      userEvent.click(screen.getByTestId('556-menuItem'));
+
+      // submit
+      userEvent.click(screen.getByTestId('createTrialButton'));
+
+      await waitForElementToBeRemoved(() =>
+        screen.queryByTestId('createTrialDialog')
+      );
+
+      expect(createTrial).toHaveBeenCalled();
+      const createTrialBody = JSON.parse(createTrial.mock.calls[0][0].body);
+      expect(createTrialBody).toMatchInlineSnapshot(`
+        Object {
+          "measurements": Array [],
+          "parameters": Array [
+            Object {
+              "parameter": "param-categorical",
+              "stringValue": "categorical-type",
+            },
+            Object {
+              "floatValue": 556,
+              "parameter": "param-discrete",
+            },
+          ],
+          "state": "REQUESTED",
+        }
+      `);
     });
 
     // TODO: add other parameters types like integer and double

--- a/jupyterlab_caip_optimizer/src/components/suggest_trials/index.tsx
+++ b/jupyterlab_caip_optimizer/src/components/suggest_trials/index.tsx
@@ -26,7 +26,7 @@ import { Trials } from './trials';
 import { RootState } from '../../store/store';
 import { setView } from '../../store/view';
 import { CreateTrial } from './create_trial';
-import {styles} from '../../utils/styles'
+import { styles } from '../../utils/styles';
 
 export interface MetricsInputs {
   [metricName: string]: string;

--- a/jupyterlab_caip_optimizer/src/components/suggest_trials/utils.ts
+++ b/jupyterlab_caip_optimizer/src/components/suggest_trials/utils.ts
@@ -241,7 +241,7 @@ export function parameterSpecToValidateInput(
             }
             break;
           case 'DOUBLE': {
-            const { minValue, maxValue } = (spec as any)
+            const { minValue = 0, maxValue = 0 } = (spec as any)
               .doubleValueSpec as DoubleValueSpec;
             const number = parseFloat(value);
             if (number < minValue) {
@@ -253,8 +253,8 @@ export function parameterSpecToValidateInput(
           }
           case 'INTEGER': {
             const {
-              minValue: minValueString,
-              maxValue: maxValueString,
+              minValue: minValueString = '0',
+              maxValue: maxValueString = '0',
             } = (spec as any).integerValueSpec as IntegerValueSpec;
             const number = parseInt(value, 10);
             const minValue = parseInt(minValueString, 10);

--- a/jupyterlab_caip_optimizer/src/service/optimizer.ts
+++ b/jupyterlab_caip_optimizer/src/service/optimizer.ts
@@ -27,7 +27,7 @@ import {
   Operation,
   SuggestTrialOperation,
 } from '../types';
-import { createTrialUrl } from '../utils/urls';
+import { createTrialUrl, addMeasurementTrialUrl } from '../utils/urls';
 
 // const AI_PLATFORM = 'https://ml.googleapis.com/v1';
 
@@ -203,6 +203,42 @@ export class OptimizerService {
       console.error(
         `Unable to fetch trials for study with name "${prettifyStudyName(
           studyName
+        )}"`
+      );
+      handleApiError(err);
+    }
+  }
+
+  /**
+   * Adds a measurement of the objective metrics to a trial. This measurement is assumed to have been taken before the trial is complete.
+   * https://cloud.google.com/ai-platform/optimizer/docs/reference/rest/v1/projects.locations.studies.trials/addMeasurement
+   * @param measurement The measurement to add.
+   * @param trialName Raw trial name.
+   * @param studyName Raw study name.
+   * @param metadata The region and project id associated with the trial.
+   */
+  async addMeasurement(
+    measurement: Measurement,
+    trialName: string,
+    studyName: string,
+    metadata: MetadataRequired
+  ): Promise<Trial> {
+    try {
+      const response = await this._transportService.submit<Trial>({
+        path: addMeasurementTrialUrl({
+          projectId: metadata.projectId,
+          region: metadata.region,
+          cleanStudyName: prettifyStudyName(studyName),
+          cleanTrialName: prettifyTrial(trialName),
+        }),
+        method: 'POST',
+        body: { measurement },
+      });
+      return response.result;
+    } catch (err) {
+      console.error(
+        `Unable to add a measurement to the trial with then name "${prettifyStudyName(
+          prettifyTrial(trialName)
         )}"`
       );
       handleApiError(err);

--- a/jupyterlab_caip_optimizer/src/service/test-constants.ts
+++ b/jupyterlab_caip_optimizer/src/service/test-constants.ts
@@ -9,6 +9,7 @@ import {
   State,
   Trial,
   Measurement,
+  TrialState,
 } from '../types';
 
 export const fakeProjectId = 'project-id';
@@ -94,7 +95,7 @@ export const fakeStudyListResponse: Study[] = [
 
 export const fakeTrial: Trial = {
   name: fakeTrialName,
-  state: State.ACTIVE,
+  state: TrialState.ACTIVE,
   parameters: [
     {
       parameter: 'param-discrete',
@@ -113,7 +114,7 @@ export const fakeTrial: Trial = {
 
 export const fakeTrialWithFinalMeasurement: Trial = {
   ...fakeTrial,
-  state: State.COMPLETED,
+  state: TrialState.COMPLETED,
   finalMeasurement: {
     stepCount: '1',
     metrics: [

--- a/jupyterlab_caip_optimizer/src/store/studies.ts
+++ b/jupyterlab_caip_optimizer/src/store/studies.ts
@@ -109,6 +109,41 @@ export const fetchTrials = createAsyncThunk<
   )
 );
 
+export const addMeasurementTrial = createAsyncThunk<
+  Trial,
+  {
+    trialName: string;
+    studyName: string;
+    measurement: Measurement;
+  },
+  {
+    state: RootState;
+  }
+>(
+  'studies/completeTrial',
+  wrapThunk(
+    async ({ trialName, studyName, measurement }, thunkAPI) => {
+      const metadata = thunkAPI.getState().metadata.data;
+      if (!metadata) {
+        console.error('No Metadata found.');
+        throw new TypeError('No metadata');
+      }
+      return await optimizer.addMeasurement(
+        measurement,
+        trialName,
+        studyName,
+        metadata
+      );
+    },
+    {
+      success: dispatch =>
+        dispatch(createSnack('Added the measurement!', 'success')),
+      error: dispatch =>
+        dispatch(createSnack('Failed to add a measurement!', 'error')),
+    }
+  )
+);
+
 export const completeTrial = createAsyncThunk<
   Trial,
   {

--- a/jupyterlab_caip_optimizer/src/types.ts
+++ b/jupyterlab_caip_optimizer/src/types.ts
@@ -43,8 +43,8 @@ export const ScaleTypeList = [
 export type ScaleType = typeof ScaleTypeList[number];
 
 export interface DoubleValueSpec {
-  minValue: number;
-  maxValue: number;
+  minValue?: number;
+  maxValue?: number;
 }
 
 /**
@@ -52,8 +52,8 @@ export interface DoubleValueSpec {
  * (https://cloud.google.com/ai-platform/optimizer/docs/reference/rest/v1/projects.locations.studies#IntegerValueSpec)
  */
 export interface IntegerValueSpec {
-  minValue: string;
-  maxValue: string;
+  minValue?: string;
+  maxValue?: string;
 }
 
 export interface CategoricalValueSpec {

--- a/jupyterlab_caip_optimizer/src/types.ts
+++ b/jupyterlab_caip_optimizer/src/types.ts
@@ -192,12 +192,20 @@ export type Parameter = ParameterBase &
       }
   );
 
+export enum TrialState {
+  STATE_UNSPECIFIED = 'STATE_UNSPECIFIED',
+  REQUESTED = 'REQUESTED',
+  ACTIVE = 'ACTIVE',
+  COMPLETED = 'COMPLETED',
+  STOPPING = 'STOPPING',
+}
+
 /**
  * Optional params are "output only" by Optimizer API
  */
 export interface Trial {
   name?: string;
-  state: State;
+  state: TrialState;
   parameters: Parameter[];
   finalMeasurement?: Measurement;
   measurements: Measurement[];

--- a/jupyterlab_caip_optimizer/src/utils/urls.ts
+++ b/jupyterlab_caip_optimizer/src/utils/urls.ts
@@ -25,6 +25,27 @@ export function getTrialsUrl(
   return `https://${region}-ml.googleapis.com/v1/projects/${projectId}/locations/${region}/studies/${cleanStudyName}/trials`;
 }
 
+export function addMeasurementTrialUrl(
+  {
+    projectId,
+    region,
+    cleanStudyName,
+    cleanTrialName,
+  }: {
+    projectId: string;
+    region: string;
+    cleanStudyName: string;
+    cleanTrialName: string;
+  } = {
+    projectId: fakeProjectId,
+    region: fakeRegion,
+    cleanStudyName: cleanFakeStudyName,
+    cleanTrialName: cleanFakeTrialName,
+  }
+): string {
+  return `https://${region}-ml.googleapis.com/v1/projects/${projectId}/locations/${region}/studies/${cleanStudyName}/trials/${cleanTrialName}:addMeasurement`;
+}
+
 export function completeTrialUrl(
   {
     projectId,


### PR DESCRIPTION
# Changes

- Updates add measurement component to allow for users to create intermediate measurements, not just final measurements.
  - Adds the add measurement API call to redux to do the above.
- Updates custom trials component to submit fully completed trials (`COMPLETED` trial state) and request for a trial with parameters (`REQUESTED` trial state).
- Fixes API study config undefined response for `minValue`/`maxValue`  by defaulting them to `0`.

# Images

- **Request trial**
![image](https://user-images.githubusercontent.com/12939414/88597856-68de7c00-d025-11ea-872f-cbf0bc8333e4.png)
- **Add intermediate Measurement**
![image](https://user-images.githubusercontent.com/12939414/88597954-94616680-d025-11ea-8f12-d51b5719f796.png)
