### PR TITLE
[BigQuery] Multiple full-window editors

### DIFF
--- a/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { withStyles, Tabs, Tab } from '@material-ui/core';
+import { withStyles, Tabs, Tab, Button } from '@material-ui/core';
+import { Code } from '@material-ui/icons';
 
 import {
   TableDetailsService,
@@ -9,6 +10,9 @@ import { Header } from '../shared/header';
 import LoadingPanel from '../loading_panel';
 import TableDetailsPanel from './table_details_panel';
 import TablePreviewPanel from './table_preview';
+import { QueryEditorTabWidget } from '../query_editor/query_editor_tab/query_editor_tab_widget';
+import { WidgetManager } from '../../utils/widgetManager/widget_manager';
+import { generateQueryId } from '../../reducers/queryEditorTabSlice';
 import { stylesheet } from 'typestyle';
 
 const localStyles = stylesheet({
@@ -132,7 +136,27 @@ export default class TableDetailsTabs extends React.Component<Props, State> {
     } else {
       return (
         <div style={{ display: 'flex', flexFlow: 'column', height: '100%' }}>
-          <Header text={this.props.table_name} />
+          <Header
+            text={this.props.table_name}
+            buttons={[
+              <Button
+                onClick={() => {
+                  const queryId = generateQueryId();
+                  WidgetManager.getInstance().launchWidget(
+                    QueryEditorTabWidget,
+                    'main',
+                    queryId,
+                    undefined,
+                    [queryId, `SELECT * FROM \`${this.props.table_id}\``]
+                  );
+                }}
+                startIcon={<Code />}
+                style={{ textTransform: 'none', color: '#1A73E8' }}
+              >
+                Query table
+              </Button>,
+            ]}
+          ></Header>
           <div className={localStyles.body}>
             <StyledTabs
               value={this.state.currentTab}

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
@@ -18,6 +18,7 @@ import ListProjectItem from './list_tree_item';
 import { WidgetManager } from '../../utils/widgetManager/widget_manager';
 import ListSearchResults from './list_search_results';
 import { QueryEditorTabWidget } from '../query_editor/query_editor_tab/query_editor_tab_widget';
+import { generateQueryId } from '../../reducers/queryEditorTabSlice';
 import { updateDataTree, addProject } from '../../reducers/dataTreeSlice';
 import { SnackbarState } from '../../reducers/snackbarSlice';
 import {
@@ -246,9 +247,13 @@ class ListItemsPanel extends React.Component<Props, State> {
             variant="contained"
             className={localStyles.editQueryButton}
             onClick={() => {
+              const queryId = generateQueryId();
               WidgetManager.getInstance().launchWidget(
                 QueryEditorTabWidget,
-                'main'
+                'main',
+                queryId,
+                undefined,
+                [queryId, undefined]
               );
             }}
           >

--- a/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab.tsx
@@ -8,6 +8,8 @@ import {
 
 interface QueryEditorTabProps {
   isVisible: boolean;
+  queryId?: string;
+  iniQuery?: string;
 }
 
 class QueryEditorTab extends React.Component<QueryEditorTabProps, {}> {
@@ -19,7 +21,7 @@ class QueryEditorTab extends React.Component<QueryEditorTabProps, {}> {
       isVisible: props.isVisible,
     };
 
-    this.queryId = generateQueryId();
+    this.queryId = this.props.queryId ?? generateQueryId();
   }
 
   render() {
@@ -32,7 +34,10 @@ class QueryEditorTab extends React.Component<QueryEditorTabProps, {}> {
           height: '100%',
         }}
       >
-        <QueryTextEditor queryId={this.queryId} />
+        <QueryTextEditor
+          queryId={this.queryId}
+          iniQuery={this.props.iniQuery}
+        />
         <QueryResults queryId={this.queryId} />
       </div>
     );

--- a/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab_widget.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab_widget.tsx
@@ -13,16 +13,24 @@ const localStyles = stylesheet({
 export class QueryEditorTabWidget extends ReduxReactWidget {
   id = 'query-editor-tab';
 
-  constructor() {
+  constructor(
+    private editorNumber: number,
+    private queryId: string,
+    private iniQuery: string
+  ) {
     super();
-    this.title.label = 'Query Editor';
+    this.title.label = `Query Editor ${this.editorNumber}`;
     this.title.closable = true;
   }
 
   renderReact() {
     return (
       <div className={localStyles.panel}>
-        <QueryEditorTab isVisible={this.isVisible} />
+        <QueryEditorTab
+          isVisible={this.isVisible}
+          queryId={this.queryId}
+          iniQuery={this.iniQuery}
+        />
       </div>
     );
   }

--- a/jupyterlab_bigquery/src/components/shared/header.tsx
+++ b/jupyterlab_bigquery/src/components/shared/header.tsx
@@ -7,9 +7,31 @@ const localStyles = stylesheet({
     fontSize: '18px',
     margin: 0,
     padding: '8px 12px 8px 24px',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  headerButton: {
+    marginRight: '36px',
   },
 });
 
-export const Header: React.SFC<{ text: string }> = props => {
-  return <header className={localStyles.header}>{props.text}</header>;
+export const Header: React.SFC<{
+  text: string;
+  buttons?: React.ReactNode[];
+}> = props => {
+  return (
+    <header className={localStyles.header}>
+      {props.text}
+      {props.buttons &&
+        props.buttons.map((button, index) => (
+          <div
+            key={`header_button_${index}`}
+            className={localStyles.headerButton}
+          >
+            {button}
+          </div>
+        ))}
+    </header>
+  );
 };

--- a/jupyterlab_bigquery/src/utils/widgetManager/widget_manager.ts
+++ b/jupyterlab_bigquery/src/utils/widgetManager/widget_manager.ts
@@ -4,6 +4,7 @@ import { configureStore, EnhancedStore } from '@reduxjs/toolkit';
 import rootReducer from '../../reducers';
 import { Widget } from '@phosphor/widgets';
 import { ReduxReactWidget } from './redux_react_widget';
+import { QueryEditorTabWidget } from '../../components/query_editor/query_editor_tab/query_editor_tab_widget';
 
 /**
  * A class that manages dataset widget instances in the Main area
@@ -13,6 +14,7 @@ export class WidgetManager {
   private widgets: { [id: string]: Widget } = {};
   private reduxWidgets: { [id: string]: ReduxReactWidget } = {};
   private store: EnhancedStore;
+  private editorNumber = 1;
 
   private constructor(private app: JupyterFrontEnd) {
     this.store = configureStore({ reducer: rootReducer });
@@ -46,7 +48,14 @@ export class WidgetManager {
 
     let widget = this.reduxWidgets[id];
     if (!widget || widget.isDisposed) {
-      widget = new widgetType(...widgetArgs);
+      if (widgetType === QueryEditorTabWidget) {
+        widget = new widgetType(this.editorNumber, ...widgetArgs);
+        this.editorNumber += 1;
+      } else {
+        widget = new widgetType(...widgetArgs);
+      }
+
+      widget.id = id;
       widget.setProviderProps({ store: this.store });
 
       if (postProcess !== undefined) {


### PR DESCRIPTION
Allows user to open multiple editor windows from the sidebar (starter query `SELECT * FROM *`) or from the table details panel (starter query `SELECT * FROM table_id`).

New tabs are named `Query Editor 1`, `Query Editor 2`, etc; they continuously rise in number. It would be easy to add the ability to rename a tab, but not sure how that flow would look, so for now we'll just name them like 1,2,3...etc.