### PR TITLE
Fix integration tests failing due to asynchronous timeout

### DIFF
--- a/jupyterlab_caip_optimizer/package.json
+++ b/jupyterlab_caip_optimizer/package.json
@@ -31,7 +31,7 @@
     "lint": "npm run lint-warnings -- --quiet",
     "pretest": "npm run lint",
     "prepack": "npm run clean && npm run build",
-    "test": "jest --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests --runInBand",
     "test-python": "../scripts/run_python_tests.sh coverage",
     "test-watch": "jest --watch",
     "watch": "tsc -b -w"

--- a/jupyterlab_caip_optimizer/src/components/create_study.spec.tsx
+++ b/jupyterlab_caip_optimizer/src/components/create_study.spec.tsx
@@ -42,6 +42,7 @@ describe('Dropdown list', () => {
 
 describe('Create Study Page', () => {
   it('creates a study and redirects to the study details page', async () => {
+    jest.setTimeout(10000);
     const createStudy = jest.fn((req, res, ctx) => {
       return res(ctx.json(fakeStudy));
     });


### PR DESCRIPTION
# Description

- Runs `jupyterlab_caip_optimizer` tests in series to prevent the asynchronous timeout error.
- Updated jest timeout to 10 seconds (default is 5 seconds) for the `Create Study Page > creates a study and redirects to the study details page` integration test