### PR TITLE
[HardwareConfiguration] Adding confirmation page before user submits VM reshaping request

### DIFF
--- a/jupyterlab_gcedetails/jupyterlab_gcedetails/handlers.py
+++ b/jupyterlab_gcedetails/jupyterlab_gcedetails/handlers.py
@@ -35,6 +35,7 @@ NVIDIA_CMD = 'nvidia-smi -q -x'
 # Constants for field names
 CPU = 'cpu'
 CUDA_VERSION = 'cuda_version'
+COUNT = 'count'
 DESCRIPTION = 'description'
 DRIVER_VERSION = 'driver_version'
 GPU = 'gpu'
@@ -100,6 +101,7 @@ async def get_gpu_details():
       NAME: '',
       DRIVER_VERSION: '',
       CUDA_VERSION: '',
+      COUNT: 0,
       GPU: 0,
       MEMORY: 0,
       TEMPERATURE: '',
@@ -119,6 +121,7 @@ async def get_gpu_details():
   details[DRIVER_VERSION] = root.find(DRIVER_VERSION).text
   details[CUDA_VERSION] = root.find(CUDA_VERSION).text
   gpu = root.find(GPU)
+  details[COUNT] = int(root.find('attached_gpus').text)
   details[NAME] = gpu.find('product_name').text
   utilization = gpu.find('utilization')
   details[GPU] = int(utilization.find('gpu_util').text[:-1].strip())

--- a/jupyterlab_gcedetails/jupyterlab_gcedetails/handlers_test.py
+++ b/jupyterlab_gcedetails/jupyterlab_gcedetails/handlers_test.py
@@ -147,6 +147,7 @@ class GetGpuDetailsTest(tornado.testing.AsyncTestCase):
             'cuda_version': '10.1',
             'driver_version': '418.87.01',
             'gpu': 100,
+            'count': 1,
             'memory': 6,
             'name': 'Tesla K80',
             'temperature': '42 C'
@@ -166,6 +167,7 @@ class GetGpuDetailsTest(tornado.testing.AsyncTestCase):
             'cuda_version': '',
             'driver_version': '',
             'gpu': 0,
+            'count': 0,
             'memory': 0,
             'name': '',
             'temperature': ''
@@ -197,6 +199,7 @@ class VmDetailsHandlerTest(tornado.testing.AsyncHTTPTestCase):
         'cuda_version': '10.1',
         'driver_version': '418.87.01',
         'gpu': 100,
+        'count': 1,
         'memory': 6,
         'name': 'Tesla K80',
         'temperature': '42 C'

--- a/jupyterlab_gcedetails/jupyterlab_gcedetails/test_data.py
+++ b/jupyterlab_gcedetails/jupyterlab_gcedetails/test_data.py
@@ -460,5 +460,5 @@ DETAILS_RESPONSE_BODY = (
     b'{"authenticate": {"sessions": {}}}, "project": {"attributes": {}, '
     b'"numericProjectId": 123456, "projectId": "test-project"}, "utilization":'
     b' {"cpu": 50, "memory": 16}, "gpu": {"cuda_version": "10.1", '
-    b'"driver_version": "418.87.01", "gpu": 100, "memory": 6, "name": "Tesla '
+    b'"driver_version": "418.87.01", "gpu": 100, "count": 1, "memory": 6, "name": "Tesla '
     b'K80", "temperature": "42 C"}}')

--- a/jupyterlab_gcedetails/src/components/confirmation_page.tsx
+++ b/jupyterlab_gcedetails/src/components/confirmation_page.tsx
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as csstips from 'csstips';
+import * as React from 'react';
+
+import {
+  BASE_FONT,
+  ActionBar,
+  SubmitButton,
+  Message,
+} from 'gcp_jupyterlab_shared';
+import { stylesheet, classes } from 'typestyle';
+import { HardwareConfiguration, ACCELERATOR_TYPES } from '../data';
+import { HardwareConfigurationDescription } from './hardware_scaling_form';
+
+interface Props {
+  formData: HardwareConfiguration;
+  onDialogClose: () => void;
+  currentConfiguration?: HardwareConfiguration;
+}
+
+export const STYLES = stylesheet({
+  title: {
+    ...BASE_FONT,
+    fontWeight: 500,
+    fontSize: '15px',
+    marginBottom: '5px',
+    ...csstips.horizontal,
+    ...csstips.flex,
+  },
+  text: {
+    display: 'block',
+  },
+  textContainer: {
+    padding: '26px 16px 0px 16px',
+  },
+  container: {
+    width: '500px',
+  },
+  topPadding: {
+    paddingTop: '15px',
+  },
+  infoMessage: {
+    margin: '20px 16px 0px 16px',
+  },
+});
+
+const INFO_MESSAGE =
+  'Updating your configuration will take 5-10 minutes. During this time you will not be able to access your notebook instance.';
+
+function getGpuTypeText(value: string) {
+  return ACCELERATOR_TYPES.find(option => option.value === value).text;
+}
+
+function displayConfiguration(
+  configuration: HardwareConfiguration,
+  title: string
+) {
+  const { machineType, attachGpu, gpuType, gpuCount } = configuration;
+
+  return (
+    <div>
+      <span className={classes(STYLES.title, STYLES.topPadding)}>{title}</span>
+      <div className={STYLES.text}>Machine type: {machineType.text}</div>
+      {attachGpu && (
+        <div className={STYLES.text}>
+          {`GPUs: ${gpuCount} ${getGpuTypeText(gpuType)}`}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// TODO: Implement submit functionality
+//eslint-disable-next-line @typescript-eslint/no-empty-function
+function submitForm() {}
+
+export function ConfirmationPage(props: Props) {
+  const { onDialogClose, formData, currentConfiguration } = props;
+
+  return (
+    <div className={STYLES.container}>
+      <div className={STYLES.textContainer}>
+        <span className={STYLES.title}>Hardware Scaling Limits</span>
+        <HardwareConfigurationDescription />
+        {currentConfiguration &&
+          displayConfiguration(currentConfiguration, 'Old Configuration')}
+        {displayConfiguration(formData, 'New Configuration')}
+      </div>
+      <div className={STYLES.infoMessage}>
+        <Message asError={false} asActivity={false} text={INFO_MESSAGE} />
+      </div>
+      <ActionBar closeLabel="Cancel" onClick={onDialogClose}>
+        <SubmitButton
+          actionPending={false}
+          onClick={() => submitForm()}
+          text="Submit"
+        />
+      </ActionBar>
+    </div>
+  );
+}

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_dialog.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_dialog.tsx
@@ -17,7 +17,12 @@
 import { Dialog } from '@material-ui/core';
 import * as React from 'react';
 import { HardwareScalingForm } from './hardware_scaling_form';
-import { HardwareConfiguration } from '../data';
+import {
+  HardwareConfiguration,
+  Details,
+  detailsToHardwareConfiguration,
+} from '../data';
+import { ConfirmationPage } from './confirmation_page';
 
 enum View {
   FORM,
@@ -27,6 +32,7 @@ enum View {
 interface Props {
   open: boolean;
   onClose: () => void;
+  details?: Details;
 }
 
 interface State {
@@ -50,13 +56,37 @@ export class HardwareScalingDialog extends React.Component<Props, State> {
     return <Dialog open={open}>{this.getDisplay()}</Dialog>;
   }
 
+  private onFormSubmit(newConfiguration: HardwareConfiguration) {
+    this.setState({
+      view: View.CONFIRMATION,
+      hardwareConfiguration: newConfiguration,
+    });
+  }
+
   private getDisplay() {
-    const { onClose } = this.props;
-    const { view } = this.state;
+    const { onClose, details } = this.props;
+    const { view, hardwareConfiguration } = this.state;
 
     switch (view) {
       case View.FORM:
-        return <HardwareScalingForm onDialogClose={onClose} />;
+        return (
+          <HardwareScalingForm
+            onDialogClose={onClose}
+            onSubmit={(configuration: HardwareConfiguration) =>
+              this.onFormSubmit(configuration)
+            }
+          />
+        );
+      case View.CONFIRMATION:
+        return (
+          <ConfirmationPage
+            onDialogClose={onClose}
+            formData={hardwareConfiguration}
+            currentConfiguration={
+              details && detailsToHardwareConfiguration(details)
+            }
+          />
+        );
     }
   }
 }

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
@@ -121,8 +121,6 @@ export class HardwareScalingForm extends React.Component<Props, State> {
     });
   }
 
-  // TODO: Implement submit functionality
-  //eslint-disable-next-line @typescript-eslint/no-empty-function
   private submitForm() {
     const configuration = { ...this.state.configuration };
     this.props.onSubmit(configuration);

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
@@ -31,19 +31,17 @@ import { SelectInput } from './select_input';
 import {
   ACCELERATOR_COUNTS_1_2_4_8,
   ACCELERATOR_TYPES,
-  Option,
   MACHINE_TYPES,
+  HardwareConfiguration,
 } from '../data';
 
 interface Props {
-  onDialogClose?: () => void;
+  onSubmit: (configuration: HardwareConfiguration) => void;
+  onDialogClose: () => void;
 }
 
 interface State {
-  machineType: Option;
-  attachGpu: boolean;
-  gpuType: string;
-  gpuCount: string;
+  configuration: HardwareConfiguration;
 }
 
 export const STYLES = stylesheet({
@@ -87,41 +85,52 @@ export class HardwareScalingForm extends React.Component<Props, State> {
     super(props);
 
     this.state = {
-      machineType: DEFAULT_MACHINE_TYPE,
-      attachGpu: false,
-      gpuType: NO_ACCELERATOR,
-      gpuCount: '',
+      configuration: {
+        machineType: DEFAULT_MACHINE_TYPE,
+        attachGpu: false,
+        gpuType: NO_ACCELERATOR,
+        gpuCount: '',
+      },
     };
   }
 
   private onAttachGpuChange(event: React.ChangeEvent<HTMLInputElement>) {
     this.setState({
-      attachGpu: event.target.checked,
-      gpuType: event.target.checked
-        ? (ACCELERATOR_TYPES[1].value as string)
-        : NO_ACCELERATOR,
-      gpuCount: event.target.checked
-        ? (ACCELERATOR_COUNTS_1_2_4_8[0].value as string)
-        : '',
+      configuration: {
+        ...this.state.configuration,
+        attachGpu: event.target.checked,
+        gpuType: event.target.checked
+          ? (ACCELERATOR_TYPES[1].value as string)
+          : NO_ACCELERATOR,
+        gpuCount: event.target.checked
+          ? (ACCELERATOR_COUNTS_1_2_4_8[0].value as string)
+          : '',
+      },
     });
   }
 
   private onGpuTypeChange(event: React.ChangeEvent<HTMLInputElement>) {
     this.setState({
-      gpuType: event.target.value,
-      gpuCount: event.target.value
-        ? (ACCELERATOR_COUNTS_1_2_4_8[0].value as string)
-        : '',
+      configuration: {
+        ...this.state.configuration,
+        gpuType: event.target.value,
+        gpuCount: event.target.value
+          ? (ACCELERATOR_COUNTS_1_2_4_8[0].value as string)
+          : '',
+      },
     });
   }
 
   // TODO: Implement submit functionality
   //eslint-disable-next-line @typescript-eslint/no-empty-function
-  private submitForm() {}
+  private submitForm() {
+    const configuration = { ...this.state.configuration };
+    this.props.onSubmit(configuration);
+  }
 
   render() {
     const { onDialogClose } = this.props;
-    const { gpuType, gpuCount, attachGpu } = this.state;
+    const { gpuType, gpuCount, attachGpu } = this.state.configuration;
 
     return (
       <div className={STYLES.container}>
@@ -135,7 +144,11 @@ export class HardwareScalingForm extends React.Component<Props, State> {
                 header: machineType.base,
                 options: machineType.configurations,
               }))}
-              onChange={machineType => this.setState({ machineType })}
+              onChange={machineType =>
+                this.setState({
+                  configuration: { ...this.state.configuration, machineType },
+                })
+              }
             />
             <div className={STYLES.checkboxContainer}>
               <CheckboxInput
@@ -165,7 +178,14 @@ export class HardwareScalingForm extends React.Component<Props, State> {
                     name="gpuCount"
                     value={gpuCount}
                     options={ACCELERATOR_COUNTS_1_2_4_8}
-                    onChange={e => this.setState({ gpuCount: e.target.value })}
+                    onChange={e =>
+                      this.setState({
+                        configuration: {
+                          ...this.state.configuration,
+                          gpuCount: e.target.value,
+                        },
+                      })
+                    }
                   />
                 </div>
               </div>
@@ -176,7 +196,7 @@ export class HardwareScalingForm extends React.Component<Props, State> {
           <SubmitButton
             actionPending={false}
             onClick={() => this.submitForm()}
-            text="Submit"
+            text="Next"
           />
         </ActionBar>
       </div>

--- a/jupyterlab_gcedetails/src/data.ts
+++ b/jupyterlab_gcedetails/src/data.ts
@@ -51,6 +51,7 @@ interface Gpu {
   name: string;
   driver_version: string;
   cuda_version: string;
+  count: string;
   gpu: number;
   memory: number;
   temperature: number;
@@ -74,6 +75,23 @@ export interface HardwareConfiguration {
   attachGpu: boolean;
   gpuType: string;
   gpuCount: string;
+}
+
+export function detailsToHardwareConfiguration(
+  details: Details
+): HardwareConfiguration {
+  const { instance, gpu } = details;
+  const machineType: Option = {
+    value: instance.machineType.name,
+    text: instance.machineType.description,
+  };
+
+  return {
+    machineType,
+    attachGpu: Boolean(gpu.name),
+    gpuType: gpu.name,
+    gpuCount: gpu.count,
+  };
 }
 
 interface AttributeMapper {
@@ -147,29 +165,6 @@ export const ACCELERATOR_COUNTS_1_2_4_8: Option[] = [
  * AI Platform Machine types.
  * https://cloud.google.com/ai-platform/training/docs/machine-types#compare-machine-types
  */
-export const MASTER_TYPES: Option[] = [
-  { value: 'n1-standard-4', text: '4 CPUs, 15 GB RAM' },
-  { value: 'n1-standard-8', text: '8 CPUs, 30 GB RAM' },
-  { value: 'n1-standard-16', text: '16 CPUs, 60 GB RAM' },
-  { value: 'n1-standard-32', text: '32 CPUs, 120 GB RAM' },
-  { value: 'n1-standard-64', text: '64 CPUs, 240 GB RAM' },
-  { value: 'n1-standard-96', text: '96 CPUs, 360 GB RAM' },
-
-  { value: 'n1-highmem-2', text: '4 CPUs, 26 GB RAM' },
-  { value: 'n1-highmem-4', text: '4 CPUs, 26 GB RAM' },
-  { value: 'n1-highmem-8', text: '8 CPUs, 52 GB RAM' },
-  { value: 'n1-highmem-16', text: '16 CPUs, 104 GB RAM' },
-  { value: 'n1-highmem-32', text: '32 CPUs, 208 GB RAM' },
-  { value: 'n1-highmem-64', text: '64 CPUs, 416 GB RAM' },
-  { value: 'n1-highmem-96', text: '96 CPUs, 624 GB RAM' },
-
-  { value: 'n1-highcpu-16', text: '16 CPUs, 14.4 GB RAM' },
-  { value: 'n1-highcpu-32', text: '32 CPUs, 28.8 GB RAM' },
-  { value: 'n1-highcpu-64', text: '64 CPUs, 57.6 GB RAM' },
-  { value: 'n1-highcpu-96', text: '96 CPUs, 86.4 GB RAM' },
-];
-
-/* CPU to Memory mappings for the Compute Engine machine types */
 export interface MachineTypeConfiguration {
   base: Option;
   configurations: Option[];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28398459/89188207-58218f00-d56c-11ea-9efe-fe52da4b01fb.png)

This commit:
- adds the confirmation page that appears in the hardware scaling dialog after the user submits the hardware scaling form
- modifies the server code to return gpu count as part of the details returned from nvidia-smi
- adds a HardwareConfiguration interface that represents a VM shape that the user can modify
- deletes some unused code (MASTER_TYPES)

Resolves #155 