### PR TITLE
[BigQuery] Resize editor on side panel open and close

### DIFF
--- a/jupyterlab_bigquery/package.json
+++ b/jupyterlab_bigquery/package.json
@@ -48,6 +48,7 @@
     "@jupyterlab/services": "^4.2.2",
     "@jupyterlab/statusbar": "^1.2.1",
     "@jupyterlab/ui-components": "^1.2.1",
+    "@lumino/widgets": "^1.13.4",
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
@@ -68,6 +69,7 @@
     "gcp_jupyterlab_shared": "^1.0.0",
     "monaco-editor": "^0.20.0",
     "react-redux": "^7.2.0",
+    "react-resize-detector": "^5.0.6",
     "redux": "^4.0.5",
     "typestyle": "^2.1.0"
   },

--- a/jupyterlab_bigquery/src/components/query_editor/query_editor_incell/query_editor_incell.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_editor_incell/query_editor_incell.tsx
@@ -9,6 +9,7 @@ import {
   generateQueryId,
 } from '../../../reducers/queryEditorTabSlice';
 import { DOMWidgetView } from '@jupyter-widgets/base';
+import ReactResizeDetector from 'react-resize-detector';
 
 interface QueryEditorInCellProps {
   queries: { [key: string]: QueryResult };
@@ -40,19 +41,26 @@ export class QueryEditorInCell extends Component<QueryEditorInCellProps, {}> {
     this.props.ipyView.touch();
 
     return (
-      <div style={{ width: '75vw' }}>
-        <QueryTextEditor
-          queryId={this.queryId}
-          iniQuery={this.iniQuery}
-          editorType="IN_CELL"
-          queryFlags={this.queryFlags}
-        />
-        {showResult ? (
-          <QueryResults queryId={this.queryId} editorType="IN_CELL" />
-        ) : (
-          undefined
-        )}
-      </div>
+      <ReactResizeDetector>
+        {({ width }) => {
+          return (
+            <div>
+              <QueryTextEditor
+                queryId={this.queryId}
+                iniQuery={this.iniQuery}
+                editorType="IN_CELL"
+                queryFlags={this.queryFlags}
+                width={width}
+              />
+              {showResult ? (
+                <QueryResults queryId={this.queryId} editorType="IN_CELL" />
+              ) : (
+                undefined
+              )}
+            </div>
+          );
+        }}
+      </ReactResizeDetector>
     );
   }
 }

--- a/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab.tsx
@@ -10,6 +10,7 @@ interface QueryEditorTabProps {
   isVisible: boolean;
   queryId?: string;
   iniQuery?: string;
+  width?: number;
 }
 
 class QueryEditorTab extends React.Component<QueryEditorTabProps, {}> {
@@ -37,6 +38,7 @@ class QueryEditorTab extends React.Component<QueryEditorTabProps, {}> {
         <QueryTextEditor
           queryId={this.queryId}
           iniQuery={this.props.iniQuery}
+          width={this.props.width}
         />
         <QueryResults queryId={this.queryId} />
       </div>

--- a/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab_widget.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab_widget.tsx
@@ -2,6 +2,9 @@ import QueryEditorTab from './query_editor_tab';
 import * as React from 'react';
 import { stylesheet } from 'typestyle';
 import { ReduxReactWidget } from '../../../utils/widgetManager/redux_react_widget';
+import { Signal } from '@phosphor/signaling';
+import { Widget } from '@lumino/widgets';
+import { UseSignal } from '@jupyterlab/apputils';
 
 const localStyles = stylesheet({
   panel: {
@@ -22,16 +25,29 @@ export class QueryEditorTabWidget extends ReduxReactWidget {
     this.title.label = `Query Editor ${this.editorNumber}`;
     this.title.closable = true;
   }
+  private resizeSignal = new Signal<this, Widget.ResizeMessage>(this);
+
+  onResize(msg: Widget.ResizeMessage) {
+    this.resizeSignal.emit(msg);
+  }
 
   renderReact() {
     return (
-      <div className={localStyles.panel}>
-        <QueryEditorTab
-          isVisible={this.isVisible}
-          queryId={this.queryId}
-          iniQuery={this.iniQuery}
-        />
-      </div>
+      <UseSignal signal={this.resizeSignal}>
+        {(_, event: Widget.ResizeMessage) => {
+          const width = event ? event.width : 0;
+          return (
+            <div className={localStyles.panel}>
+              <QueryEditorTab
+                isVisible={this.isVisible}
+                queryId={this.queryId}
+                iniQuery={this.iniQuery}
+                width={width}
+              />
+            </div>
+          );
+        }}
+      </UseSignal>
     );
   }
 }

--- a/jupyterlab_bigquery/style/index.css
+++ b/jupyterlab_bigquery/style/index.css
@@ -18,3 +18,6 @@
   background-image: url('./images/model_20px.svg');
   background-size: contain;
 }
+.jp-OutputArea-child .jp-OutputArea-output {
+  overflow: auto;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13625,14 +13625,15 @@
       }
     },
     "react-resize-detector": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-2.3.0.tgz",
-      "integrity": "sha512-oCAddEWWeFWYH5FAcHdBYcZjAw9fMzRUK9sWSx6WvSSOPVRxcHd5zTIGy/mOus+AhN/u6T4TMiWxvq79PywnJQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-5.0.6.tgz",
+      "integrity": "sha512-wvyK350xvq3GgRDd8ENE0T5wqTBniGhKuK0rGHeg0L79AlW+2Be6ulecGCzCpC6CE7Zshohf1GZyDaf2onoGFg==",
       "requires": {
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "prop-types": "^15.6.0",
-        "resize-observer-polyfill": "^1.5.0"
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15",
+        "prop-types": "^15.7.2",
+        "raf-schd": "^4.0.2",
+        "resize-observer-polyfill": "^1.5.1"
       }
     },
     "react-smooth": {
@@ -13901,6 +13902,17 @@
           "version": "2.6.11",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
           "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+        },
+        "react-resize-detector": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-2.3.0.tgz",
+          "integrity": "sha512-oCAddEWWeFWYH5FAcHdBYcZjAw9fMzRUK9sWSx6WvSSOPVRxcHd5zTIGy/mOus+AhN/u6T4TMiWxvq79PywnJQ==",
+          "requires": {
+            "lodash.debounce": "^4.0.8",
+            "lodash.throttle": "^4.1.1",
+            "prop-types": "^15.6.0",
+            "resize-observer-polyfill": "^1.5.0"
+          }
         }
       }
     },


### PR DESCRIPTION
Uses resize signals from the full window widget and [react-resize-detector](https://www.npmjs.com/package/react-resize-detector) in the in-cell element to resize the query editor with `editor.layout()`. 

I was hoping to implement the resizing in both types of editor (both in-cell and full window) with widget signals, but I couldn't get it to work properly with the in-cell editor. However, it seems that react-resize-detector is fairly widely used and it includes a polyfill so that the resizing is compatible in most web browsers, so I feel ok about using it.

I'm wondering if we should convert the widget signal resizing to also use react-resize-detector just for consistency? Currently there is a slight delay in the in-cell editor resizing at times, so you will see a ghost of the old size for a second before it resizes. This does not occur in the full-window editor, so this might be a reason to refrain from converting everything to react-resize-detector. However, would love to hear any thoughts on this.