### PR TITLE
[BigQuery] Add basic model details

### DIFF
--- a/jupyterlab_bigquery/jupyterlab_bigquery/__init__.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/__init__.py
@@ -3,7 +3,7 @@ from notebook.utils import url_path_join
 
 
 from jupyterlab_bigquery.list_items_handler import Handlers
-from jupyterlab_bigquery.details_handler import DatasetDetailsHandler, TablePreviewHandler, TableDetailsHandler, ViewDetailsHandler
+from jupyterlab_bigquery.details_handler import DatasetDetailsHandler, TablePreviewHandler, TableDetailsHandler, ViewDetailsHandler, ModelDetailsHandler
 from jupyterlab_bigquery.version import VERSION
 from jupyterlab_bigquery.pagedAPI_handler import PagedQueryHandler
 from jupyterlab_bigquery.query_incell_editor import QueryIncellEditor, _cell_magic
@@ -43,6 +43,7 @@ def load_jupyter_server_extension(nb_server_app):
         make_endpoint('tabledetails', TableDetailsHandler),
         make_endpoint('tablepreview', TablePreviewHandler),
         make_endpoint('viewdetails', ViewDetailsHandler),
+        make_endpoint('modeldetails', ModelDetailsHandler),
         make_endpoint('query', PagedQueryHandler)
     ])
 

--- a/jupyterlab_bigquery/jupyterlab_bigquery/details_handler/__init__.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/details_handler/__init__.py
@@ -1,1 +1,1 @@
-from .details_handler import DatasetDetailsHandler, TableDetailsHandler, TablePreviewHandler, ViewDetailsHandler, format_preview_fields, format_preview_rows
+from .details_handler import DatasetDetailsHandler, TableDetailsHandler, TablePreviewHandler, ViewDetailsHandler, ModelDetailsHandler, format_preview_fields, format_preview_rows

--- a/jupyterlab_bigquery/jupyterlab_bigquery/tests/details_handlers_test.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/tests/details_handlers_test.py
@@ -4,7 +4,9 @@ import unittest
 import datetime
 from unittest.mock import Mock, MagicMock, patch
 
-from jupyterlab_bigquery.details_handler.details_handler import get_dataset_details, get_table_details, get_table_preview, get_view_details
+from jupyterlab_bigquery.details_handler.details_handler import get_dataset_details, get_table_details, get_table_preview, get_view_details, get_model_details
+from google.cloud.bigquery.enums import StandardSqlDataTypes, SqlTypeNames
+from google.cloud.bigquery_v2.gapic.enums import Model
 
 class TestDatasetDetails(unittest.TestCase):
   def testGetDatasetDetailsFull(self):
@@ -250,7 +252,7 @@ class TestTableDetails(unittest.TestCase):
     result = get_table_details(client, 'some_table_id')
     self.assertEqual(expected, result)
   
-class TestTablePreviewPreview(unittest.TestCase):
+class TestTablePreview(unittest.TestCase):
     def testNestedTable(self):
         # ensures records schema names are properly displayed and items
         # within records are properly separated
@@ -458,8 +460,97 @@ class TestViewDetails(unittest.TestCase):
     }
 
     result = get_view_details(client, 'some_view_id')
-    self.maxDiff = None
     self.assertEqual(expected, result)
+
+
+class TestModelDetails(unittest.TestCase):
+    def testGetModelDetailsFull(self):
+        client = Mock()
+
+        label_col_0 = Mock()
+        label_col_0.name = 'schema_label_0'
+        label_col_0.type = Mock(type_kind = 7)
+        label_col_1 = Mock()
+        label_col_1.name = 'schema_label_1'
+        label_col_1.type = Mock(type_kind = 9)
+
+        feature_col_0 = Mock()
+        feature_col_0.name = 'feature_col_0'
+        feature_col_0.type = Mock(type_kind = 8)
+    
+        model = Mock(
+            project = 'project_id',
+            dataset_id = 'dataset_id',
+            model_id = 'model_id',
+            description = 'description of model',
+            labels = {'label_0': 'value_0', 'label_1': 'value_1'},
+            created = datetime.datetime(2020, 7, 14, 13, 23, 45, 67, tzinfo=None),
+            expires = datetime.datetime(2021, 7, 14, 13, 23, 45, 67, tzinfo=None),
+            location = 'US',
+            modified = datetime.datetime(2020, 7, 15, 15, 11, 23, 32, tzinfo=None),
+            model_type = 0,
+            label_columns = [label_col_0, label_col_1],
+            feature_columns = [feature_col_0]
+        )
+        client.get_model = Mock(return_value = model)
+
+        expected = {
+            'details': {
+                'id': 'project_id.dataset_id.model_id',
+                'name': 'model_id',
+                'description': 'description of model',
+                'labels': ['label_0: value_0', 'label_1: value_1'],
+                'date_created': 'Jul 14, 2020,  1:23:45 PM',
+                'expires': 'Jul 14, 2021,  1:23:45 PM',
+                'location': 'US',
+                'last_modified': 'Jul 15, 2020,  3:11:23 PM',
+                'model_type': Model.ModelType(0).name,
+                'schema_labels': [{'name': 'schema_label_0', 'type': SqlTypeNames[StandardSqlDataTypes(7).name].name}, {'name': 'schema_label_1', 'type': StandardSqlDataTypes(9).name}],
+                'feature_columns': [{'name': 'feature_col_0', 'type': SqlTypeNames[StandardSqlDataTypes(8).name].name}]
+            }
+        }
+
+        result = get_model_details(client, 'some_model_id')
+        self.assertEqual(expected, result)
+
+    def testGetModelDetailsEmptyFields(self):
+        client = Mock()
+
+        model = Mock(
+            project = 'project_id',
+            dataset_id = 'dataset_id',
+            model_id = 'model_id',
+            description = None,
+            labels = {},
+            created = datetime.datetime(2020, 7, 14, 13, 23, 45, 67, tzinfo=None),
+            expires = datetime.datetime(2021, 7, 14, 13, 23, 45, 67, tzinfo=None),
+            location = 'US',
+            modified = datetime.datetime(2020, 7, 15, 15, 11, 23, 32, tzinfo=None),
+            model_type = 0,
+            label_columns = [],
+            feature_columns = []
+        )
+        client.get_model = Mock(return_value = model)
+
+        expected = {
+            'details': {
+                'id': 'project_id.dataset_id.model_id',
+                'name': 'model_id',
+                'description': None,
+                'labels': None,
+                'date_created': 'Jul 14, 2020,  1:23:45 PM',
+                'expires': 'Jul 14, 2021,  1:23:45 PM',
+                'location': 'US',
+                'last_modified': 'Jul 15, 2020,  3:11:23 PM',
+                'model_type': Model.ModelType(0).name,
+                'schema_labels': [],
+                'feature_columns': []
+            }
+        }
+
+        result = get_model_details(client, 'some_model_id')
+        self.assertEqual(expected, result)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
@@ -15,6 +15,8 @@ import Editor from '@monaco-editor/react';
 import { monaco } from '@monaco-editor/react';
 
 import { SchemaField } from './service/list_table_details';
+import { ModelSchema } from './service/list_model_details';
+import { StripedRows } from '../shared/striped_rows';
 
 export const localStyles = stylesheet({
   header: {
@@ -53,15 +55,11 @@ export const localStyles = stylesheet({
   },
 });
 
-const TableHeadCell = withStyles({
+export const TableHeadCell: React.ComponentType<any> = withStyles({
   root: {
     backgroundColor: '#f0f0f0',
   },
 })(TableCell);
-
-const getStripedStyle = index => {
-  return { background: index % 2 ? 'white' : '#fafafa' };
-};
 
 const formatFieldName = name => {
   if (name.includes('.')) {
@@ -84,13 +82,15 @@ interface SharedDetails {
   name: string;
   schema?: SchemaField[];
   query?: string;
+  schema_labels?: ModelSchema[];
+  feature_columns?: ModelSchema[];
 }
 
 interface Props {
   details: SharedDetails;
   rows: any[];
   // TODO(cxjia): figure out a shared typing for these rows
-  detailsType: 'DATASET' | 'TABLE' | 'VIEW';
+  detailsType: 'DATASET' | 'TABLE' | 'VIEW' | 'MODEL';
 }
 
 const getTitle = type => {
@@ -101,6 +101,8 @@ const getTitle = type => {
       return 'Table info';
     case 'VIEW':
       return 'View info';
+    case 'MODEL':
+      return 'Model details';
   }
 };
 
@@ -166,18 +168,7 @@ export const DetailsPanel: React.SFC<Props> = props => {
 
           <Grid item xs={12}>
             <div className={localStyles.title}>{getTitle(detailsType)}</div>
-            {rows.map((row, index) => (
-              <div
-                key={index}
-                className={localStyles.row}
-                style={{ ...getStripedStyle(index) }}
-              >
-                <div className={localStyles.rowTitle}>
-                  <b>{row.name}</b>
-                </div>
-                <div>{row.value}</div>
-              </div>
-            ))}
+            <StripedRows rows={rows} />
           </Grid>
         </Grid>
 
@@ -245,6 +236,72 @@ export const DetailsPanel: React.SFC<Props> = props => {
               }}
               editorDidMount={handleEditorDidMount}
             />
+          </div>
+        )}
+
+        {detailsType === 'MODEL' && (
+          <div>
+            <div className={localStyles.title} style={{ marginTop: '32px' }}>
+              Label columns
+            </div>
+            <div>
+              {details.schema_labels && details.schema_labels.length > 0 ? (
+                <Table
+                  size="small"
+                  style={{ width: 'auto', tableLayout: 'auto' }}
+                >
+                  <TableHead>
+                    <TableRow>
+                      <TableHeadCell>Field name</TableHeadCell>
+                      <TableHeadCell>Type</TableHeadCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {details.schema_labels.map((field, index) => {
+                      return (
+                        <TableRow key={`schema_label_row_${index}`}>
+                          <TableCell>{field.name}</TableCell>
+                          <TableCell>{field.type}</TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              ) : (
+                'Model does not have any label columns.'
+              )}
+            </div>
+
+            <div className={localStyles.title} style={{ marginTop: '24px' }}>
+              Feature columns
+            </div>
+            <div>
+              {details.feature_columns && details.feature_columns.length > 0 ? (
+                <Table
+                  size="small"
+                  style={{ width: 'auto', tableLayout: 'auto' }}
+                >
+                  <TableHead>
+                    <TableRow>
+                      <TableHeadCell>Field name</TableHeadCell>
+                      <TableHeadCell>Type</TableHeadCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {details.feature_columns.map((field, index) => {
+                      return (
+                        <TableRow key={`schema_feature_row_${index}`}>
+                          <TableCell>{field.name}</TableCell>
+                          <TableCell>{field.type}</TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              ) : (
+                'Model does not have any feature columns.'
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/jupyterlab_bigquery/src/components/details_panel/model_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/model_details_panel.tsx
@@ -1,49 +1,39 @@
 import * as React from 'react';
-
 import {
-  DatasetDetailsService,
-  DatasetDetails,
-} from './service/list_dataset_details';
-import { Header } from '../shared/header';
+  ModelDetailsService,
+  ModelDetails,
+} from './service/list_model_details';
 import LoadingPanel from '../loading_panel';
 import { DetailsPanel } from './details_panel';
-import { stylesheet } from 'typestyle';
-
-export const localStyles = stylesheet({
-  body: {
-    marginBottom: '24px',
-    marginRight: '24px',
-    marginLeft: '24px',
-    height: '100%',
-    overflowY: 'auto',
-  },
-});
+import { Header } from '../shared/header';
+import { localStyles } from './dataset_details_panel';
 
 interface Props {
-  datasetDetailsService: DatasetDetailsService;
+  modelDetailsService: ModelDetailsService;
   isVisible: boolean;
-  dataset_id: string;
+  modelId: string;
+  modelName: string;
 }
 
 interface State {
   hasLoaded: boolean;
   isLoading: boolean;
-  details: DatasetDetails;
+  details: ModelDetails;
   rows: DetailRow[];
 }
 
 interface DetailRow {
   name: string;
-  value: string;
+  value: string | number;
 }
 
-export default class DatasetDetailsPanel extends React.Component<Props, State> {
+export default class ModelDetailsPanel extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
       hasLoaded: false,
       isLoading: false,
-      details: { details: {} } as DatasetDetails,
+      details: { details: {} } as ModelDetails,
       rows: [],
     };
   }
@@ -56,38 +46,37 @@ export default class DatasetDetailsPanel extends React.Component<Props, State> {
     }
   }
 
-  formatMs(ms) {
-    const days = ms / 86400000;
-    return `${days} day${days > 1 ? 's' : ''} 0 hr`;
-  }
-
   private async getDetails() {
     try {
       this.setState({ isLoading: true });
-      const details = await this.props.datasetDetailsService.listDatasetDetails(
-        this.props.dataset_id
+      const details = await this.props.modelDetailsService.listModelDetails(
+        this.props.modelId
       );
 
       const detailsObj = details.details;
       const rows = [
-        { name: 'Dataset ID', value: detailsObj.id },
-        { name: 'Created', value: detailsObj.date_created },
+        { name: 'Model ID', value: detailsObj.id },
+        { name: 'Date created', value: detailsObj.date_created },
         {
-          name: 'Default table expiration',
-          value: detailsObj.default_expiration
-            ? this.formatMs(detailsObj.default_expiration)
-            : 'Never',
+          name: 'Model expiration',
+          value: detailsObj.expires ? detailsObj.expires : 'Never',
         },
-        { name: 'Last modified', value: detailsObj.last_modified },
+        {
+          name: 'Date modified',
+          value: detailsObj.last_modified,
+        },
         {
           name: 'Data location',
           value: detailsObj.location ? detailsObj.location : 'None',
         },
+        {
+          name: 'Model type',
+          value: detailsObj.model_type,
+        },
       ];
-
       this.setState({ hasLoaded: true, details, rows });
     } catch (err) {
-      console.warn('Error retrieving dataset details', err);
+      console.warn('Error retrieving model details', err);
     } finally {
       this.setState({ isLoading: false });
     }
@@ -99,12 +88,12 @@ export default class DatasetDetailsPanel extends React.Component<Props, State> {
     } else {
       return (
         <div style={{ height: '100%' }}>
-          <Header text={this.props.dataset_id} />
+          <Header text={this.props.modelName} />
           <div className={localStyles.body}>
             <DetailsPanel
               details={this.state.details.details}
               rows={this.state.rows}
-              detailsType="DATASET"
+              detailsType="MODEL"
             />
           </div>
         </div>

--- a/jupyterlab_bigquery/src/components/details_panel/model_details_widget.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/model_details_widget.tsx
@@ -1,0 +1,33 @@
+import { ReactWidget } from '@jupyterlab/apputils';
+import * as React from 'react';
+
+import { ModelDetailsService } from './service/list_model_details';
+import ModelDetailsPanel from './model_details_panel';
+
+/** Widget to be registered in the main panel. */
+export class ModelDetailsWidget extends ReactWidget {
+  id = 'model-details-widget';
+
+  constructor(
+    private readonly service: ModelDetailsService,
+    private readonly model_id: string,
+    private readonly name: string
+  ) {
+    super();
+    this.title.iconClass = 'jp-Icon jp-Icon-20 jp-BigQueryIcon';
+    this.title.caption = `Model Details for ${this.model_id}`;
+    this.title.label = this.name;
+    this.title.closable = true;
+  }
+
+  render() {
+    return (
+      <ModelDetailsPanel
+        isVisible={this.isVisible}
+        modelId={this.model_id}
+        modelName={this.name}
+        modelDetailsService={this.service}
+      />
+    );
+  }
+}

--- a/jupyterlab_bigquery/src/components/details_panel/service/list_model_details.ts
+++ b/jupyterlab_bigquery/src/components/details_panel/service/list_model_details.ts
@@ -1,0 +1,58 @@
+import { ServerConnection } from '@jupyterlab/services';
+import { URLExt } from '@jupyterlab/coreutils';
+
+export interface ModelDetailsObject {
+  id: string;
+  name: string;
+  description: string;
+  labels: string[];
+  date_created: string;
+  expires: string;
+  location: string;
+  last_modified: string;
+  model_type: string;
+  schema_labels: ModelSchema[];
+  feature_columns: ModelSchema[];
+}
+
+export interface ModelSchema {
+  name: string;
+  type: string;
+}
+
+export interface ModelDetails {
+  details: ModelDetailsObject;
+}
+
+export class ModelDetailsService {
+  async listModelDetails(modelId: string): Promise<ModelDetails> {
+    return new Promise((resolve, reject) => {
+      const serverSettings = ServerConnection.makeSettings();
+      const requestUrl = URLExt.join(
+        serverSettings.baseUrl,
+        'bigquery/v1/modeldetails'
+      );
+      const body = { modelId: modelId };
+      const requestInit: RequestInit = {
+        body: JSON.stringify(body),
+        method: 'POST',
+      };
+      ServerConnection.makeRequest(
+        requestUrl,
+        requestInit,
+        serverSettings
+      ).then(response => {
+        response.json().then(content => {
+          if (content.error) {
+            console.error(content.error);
+            reject(content.error);
+            return [];
+          }
+          resolve({
+            details: content.details,
+          });
+        });
+      });
+    });
+  }
+}

--- a/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { withStyles, Tabs, Tab, Button } from '@material-ui/core';
+import { Button } from '@material-ui/core';
 import { Code } from '@material-ui/icons';
 
 import {
@@ -7,6 +7,7 @@ import {
   TableDetails,
 } from './service/list_table_details';
 import { Header } from '../shared/header';
+import { StyledTabs, StyledTab, TabPanel } from '../shared/tabs';
 import LoadingPanel from '../loading_panel';
 import TableDetailsPanel from './table_details_panel';
 import TablePreviewPanel from './table_preview';
@@ -15,7 +16,7 @@ import { WidgetManager } from '../../utils/widgetManager/widget_manager';
 import { generateQueryId } from '../../reducers/queryEditorTabSlice';
 import { stylesheet } from 'typestyle';
 
-const localStyles = stylesheet({
+export const localStyles = stylesheet({
   body: {
     margin: '24px',
     marginBottom: 0,
@@ -26,42 +27,6 @@ const localStyles = stylesheet({
     flexDirection: 'column',
   },
 });
-
-const StyledTabs = withStyles({
-  root: {
-    borderBottom: '1px solid #e8e8e8',
-    minHeight: 'auto',
-    padding: 0,
-  },
-  indicator: {
-    backgroundColor: '#0d68ff',
-    height: '2.5px',
-  },
-})(Tabs);
-
-const StyledTab = withStyles({
-  root: {
-    textTransform: 'none',
-    minWidth: 'auto',
-    minHeight: 'auto',
-    fontSize: '13px',
-    '&:hover': {
-      color: '#0d68ff',
-      opacity: 1,
-    },
-    '&$selected': {
-      color: '#0d68ff',
-    },
-    '&:focus': {
-      color: '#0d68ff',
-    },
-  },
-  selected: {},
-})((props: StyledTabProps) => <Tab disableRipple {...props} />);
-
-interface StyledTabProps {
-  label: string;
-}
 
 interface Props {
   tableDetailsService: TableDetailsService;
@@ -86,32 +51,6 @@ interface DetailRow {
 enum TabInds {
   details = 0,
   preview,
-}
-
-interface TabPanelProps {
-  children?: React.ReactNode;
-  index: number;
-  value: number;
-}
-
-function TabPanel(props: TabPanelProps) {
-  const { children, value, index } = props;
-
-  return (
-    <div
-      id={`tabpanel-${index}`}
-      style={{
-        flex: 1,
-        minHeight: 0,
-        flexDirection: 'column',
-        display: value !== index ? 'none' : 'flex',
-        overflowX: value === TabInds.preview ? 'auto' : 'hidden',
-        overflowY: 'auto',
-      }}
-    >
-      {children}
-    </div>
-  );
 }
 
 export default class TableDetailsTabs extends React.Component<Props, State> {
@@ -165,14 +104,22 @@ export default class TableDetailsTabs extends React.Component<Props, State> {
               <StyledTab label="Details" />
               <StyledTab label="Preview" />
             </StyledTabs>
-            <TabPanel value={this.state.currentTab} index={TabInds.details}>
+            <TabPanel
+              value={this.state.currentTab}
+              index={TabInds.details}
+              TabInds={TabInds}
+            >
               <TableDetailsPanel
                 tableId={this.props.table_id}
                 isVisible={this.props.isVisible}
                 tableDetailsService={this.props.tableDetailsService}
               />
             </TabPanel>
-            <TabPanel value={this.state.currentTab} index={TabInds.preview}>
+            <TabPanel
+              value={this.state.currentTab}
+              index={TabInds.preview}
+              TabInds={TabInds}
+            >
               <TablePreviewPanel
                 tableId={this.props.table_id}
                 isVisible={this.props.isVisible}

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
@@ -29,6 +29,8 @@ import { TableDetailsWidget } from '../details_panel/table_details_widget';
 import { TableDetailsService } from '../details_panel/service/list_table_details';
 import { ViewDetailsWidget } from '../details_panel/view_details_widget';
 import { ViewDetailsService } from '../details_panel/service/list_view_details';
+import { ModelDetailsWidget } from '../details_panel/model_details_widget';
+import { ModelDetailsService } from '../details_panel/service/list_model_details';
 import { updateProject, updateDataset } from '../../reducers/dataTreeSlice';
 import { openSnackbar } from '../../reducers/snackbarSlice';
 
@@ -128,6 +130,19 @@ export function BuildTree(project, context, expandProject, expandDataset) {
     );
   };
 
+  const openModelDetails = (event, model) => {
+    event.stopPropagation();
+    const service = new ModelDetailsService();
+    const widgetType = ModelDetailsWidget;
+    context.manager.launchWidgetForId(
+      model.id,
+      widgetType,
+      service,
+      model.id,
+      model.name
+    );
+  };
+
   const getIcon = iconType => {
     return (
       <Icon style={{ display: 'flex', alignContent: 'center' }}>
@@ -213,6 +228,7 @@ export function BuildTree(project, context, expandProject, expandDataset) {
             <Typography>{model.name}</Typography>
           </ContextMenu>
         }
+        onDoubleClick={event => openModelDetails(event, model)}
       />
     );
   };

--- a/jupyterlab_bigquery/src/components/shared/striped_rows.tsx
+++ b/jupyterlab_bigquery/src/components/shared/striped_rows.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { stylesheet } from 'typestyle';
+
+const localStyles = stylesheet({
+  row: {
+    display: 'flex',
+    padding: '6px',
+  },
+  rowTitle: {
+    width: '200px',
+  },
+});
+
+export const getStripedStyle = index => {
+  return { background: index % 2 ? 'white' : '#fafafa' };
+};
+
+export const StripedRows = props => {
+  return (
+    <div>
+      {props.rows.map((row, index) => (
+        <div
+          key={index}
+          className={localStyles.row}
+          style={{ ...getStripedStyle(index) }}
+        >
+          <div className={localStyles.rowTitle}>
+            <b>{row.name}</b>
+          </div>
+          <div>{row.value}</div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/jupyterlab_bigquery/src/components/shared/tabs.tsx
+++ b/jupyterlab_bigquery/src/components/shared/tabs.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { withStyles, Tabs, Tab } from '@material-ui/core';
+
+export const StyledTabs: React.ComponentType<any> = withStyles({
+  root: {
+    borderBottom: '1px solid #e8e8e8',
+    minHeight: 'auto',
+    padding: 0,
+  },
+  indicator: {
+    backgroundColor: '#0d68ff',
+    height: '2.5px',
+  },
+})(Tabs);
+
+export const StyledTab: React.ComponentType<StyledTabProps> = withStyles({
+  root: {
+    textTransform: 'none',
+    minWidth: 'auto',
+    minHeight: 'auto',
+    fontSize: '13px',
+    '&:hover': {
+      color: '#0d68ff',
+      opacity: 1,
+    },
+    '&$selected': {
+      color: '#0d68ff',
+    },
+    '&:focus': {
+      color: '#0d68ff',
+    },
+  },
+  selected: {},
+})((props: StyledTabProps) => <Tab disableRipple {...props} />);
+
+interface StyledTabProps {
+  label: string;
+}
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+  TabInds: any;
+}
+
+export function TabPanel(props: TabPanelProps) {
+  const { children, value, index, TabInds } = props;
+
+  return (
+    <div
+      id={`tabpanel-${index}`}
+      style={{
+        flex: 1,
+        minHeight: 0,
+        flexDirection: 'column',
+        display: value !== index ? 'none' : 'flex',
+        overflowX: value === TabInds.preview ? 'auto' : 'hidden',
+        overflowY: 'auto',
+      }}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds extremely basic model details with description, labels, some metadata, and schema. Future steps include Training Options, and potentially the Training and Evaluation tabs for certain types of models.

![natalitymodel](https://user-images.githubusercontent.com/48393093/89340723-b5fac780-d68f-11ea-965e-5a65bd1d6362.png)

Besides adding the model widget, this PR also pulls out shared components for striped rows and panel tabs.