### PR TITLE
[BigQuery] Refactor tree and implement refreshing

### DIFF
--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item_widget.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item_widget.tsx
@@ -2,12 +2,7 @@ import { UseSignal } from '@jupyterlab/apputils';
 import { Signal } from '@phosphor/signaling';
 import * as React from 'react';
 import { ReduxReactWidget } from '../../utils/widgetManager/redux_react_widget';
-import {
-  ListProjectsService,
-  ListDatasetsService,
-  ListTablesService,
-  ListModelsService,
-} from './service/list_items';
+import { ListProjectsService } from './service/list_items';
 import ListItemsPanel from './list_tree_panel';
 import { Context } from './list_tree_panel';
 
@@ -18,9 +13,6 @@ export default class ListItemsWidget extends ReduxReactWidget {
 
   constructor(
     private readonly listProjectsService: ListProjectsService,
-    private readonly listDatasetsService: ListDatasetsService,
-    private readonly listTablesService: ListTablesService,
-    private readonly listModelsService: ListModelsService,
     private context: Context
   ) {
     super();
@@ -43,9 +35,6 @@ export default class ListItemsWidget extends ReduxReactWidget {
           <ListItemsPanel
             isVisible={isVisible}
             listProjectsService={this.listProjectsService}
-            listDatasetsService={this.listDatasetsService}
-            listTablesService={this.listTablesService}
-            listModelsService={this.listModelsService}
             context={this.context}
           />
         )}

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
@@ -1,17 +1,22 @@
-import { LinearProgress, Button, Portal } from '@material-ui/core';
+import {
+  LinearProgress,
+  Button,
+  Portal,
+  IconButton,
+  Tooltip,
+} from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
+import RefreshIcon from '@material-ui/icons/Refresh';
 import * as csstips from 'csstips';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { stylesheet } from 'typestyle';
 import { JupyterFrontEnd } from '@jupyterlab/application';
+import { INotebookTracker } from '@jupyterlab/notebook';
 
 import {
   ListProjectsService,
   DataTree,
-  ListDatasetsService,
-  ListTablesService,
-  ListModelsService,
   GetProjectService,
 } from './service/list_items';
 import ListProjectItem from './list_tree_item';
@@ -31,9 +36,6 @@ import CustomSnackbar from './snackbar';
 
 interface Props {
   listProjectsService: ListProjectsService;
-  listDatasetsService: ListDatasetsService;
-  listTablesService: ListTablesService;
-  listModelsService: ListModelsService;
   isVisible: boolean;
   context: Context;
   updateDataTree: any;
@@ -47,6 +49,7 @@ interface Props {
 export interface Context {
   app: JupyterFrontEnd;
   manager: WidgetManager;
+  notebookTrack: INotebookTracker;
 }
 
 interface State {
@@ -76,7 +79,6 @@ const localStyles = stylesheet({
     flexDirection: 'row',
     display: 'flex',
     justifyContent: 'space-between',
-    flexWrap: 'wrap',
   },
   resources: {
     borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)',
@@ -95,7 +97,6 @@ const localStyles = stylesheet({
     textTransform: 'uppercase',
     display: 'flex',
     flexDirection: 'row',
-    flexWrap: 'wrap',
     marginBottom: '8px',
   },
   search: {
@@ -105,15 +106,32 @@ const localStyles = stylesheet({
     flexGrow: 1,
     display: 'flex',
     justifyContent: 'flex-end',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+  },
+  buttonWithIcon: {
+    flexDirection: 'row',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  buttonLabel: {
+    fontWeight: 400,
+    fontFamily: 'var(--jp-ui-font-family)',
+    fontSize: 'var(--jp-ui-font-size1)',
+    textTransform: 'initial',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
   editQueryButton: {
     margin: 'auto',
     flexGrow: 0,
+    minWidth: 0,
   },
   pinProjectsButton: {
     margin: 'auto',
     flexGrow: 0,
     padding: 0,
+    minWidth: 0,
   },
   list: {
     margin: 0,
@@ -159,17 +177,6 @@ const localStyles = stylesheet({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
-  },
-  buttonWithIcon: {
-    flexDirection: 'row',
-    display: 'flex',
-    alignItems: 'center',
-  },
-  buttonLabel: {
-    fontWeight: 400,
-    fontFamily: 'var(--jp-ui-font-family)',
-    fontSize: 'var(--jp-ui-font-size1)',
-    textTransform: 'initial',
   },
 });
 
@@ -289,6 +296,10 @@ class ListItemsPanel extends React.Component<Props, State> {
     this.setState({ pinProjectDialogOpen: false });
   };
 
+  handleRefreshAll = () => {
+    this.getProjects();
+  };
+
   async componentWillMount() {
     try {
       //empty
@@ -327,41 +338,56 @@ class ListItemsPanel extends React.Component<Props, State> {
           <CustomSnackbar open={snackbar.open} message={snackbar.message} />
         </Portal>
         <header className={localStyles.header}>
-          BigQuery Extension
+          <div>BigQuery Extension</div>
           <div className={localStyles.buttonContainer}>
-            <Button
-              style={{ color: COLORS.blue }}
-              size="small"
-              variant="outlined"
-              className={localStyles.editQueryButton}
-              onClick={() => {
-                const queryId = generateQueryId();
-                WidgetManager.getInstance().launchWidget(
-                  QueryEditorTabWidget,
-                  'main',
-                  queryId,
-                  undefined,
-                  [queryId, undefined]
-                );
-              }}
-            >
-              <div className={localStyles.buttonLabel}>Open SQL editor</div>
-            </Button>
+            <Tooltip title="Open SQL editor">
+              <Button
+                style={{ color: COLORS.blue }}
+                size="small"
+                variant="outlined"
+                className={localStyles.editQueryButton}
+                onClick={() => {
+                  const queryId = generateQueryId();
+                  WidgetManager.getInstance().launchWidget(
+                    QueryEditorTabWidget,
+                    'main',
+                    queryId,
+                    undefined,
+                    [queryId, undefined]
+                  );
+                }}
+              >
+                <div className={localStyles.buttonLabel}>Open SQL editor</div>
+              </Button>
+            </Tooltip>
           </div>
         </header>
         <div className={localStyles.resources}>
           <div className={localStyles.resourcesTitle}>
             <div>Resources</div>
             <div className={localStyles.buttonContainer}>
-              <Button
-                size="small"
-                variant="outlined"
-                className={localStyles.pinProjectsButton}
-                onClick={this.handleOpenPinProject}
-                startIcon={<AddIcon />}
-              >
-                <div className={localStyles.buttonLabel}>Pin project</div>
-              </Button>
+              <Tooltip title="Refresh">
+                <IconButton
+                  size="small"
+                  aria-label="close"
+                  color="inherit"
+                  onClick={this.handleRefreshAll}
+                >
+                  <RefreshIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Pin project">
+                <Button
+                  size="small"
+                  variant="outlined"
+                  style={{ minWidth: 0 }}
+                  className={localStyles.pinProjectsButton}
+                  onClick={this.handleOpenPinProject}
+                  startIcon={<AddIcon />}
+                >
+                  <div className={localStyles.buttonLabel}>Pin project</div>
+                </Button>
+              </Tooltip>
             </div>
           </div>
           <div
@@ -379,12 +405,7 @@ class ListItemsPanel extends React.Component<Props, State> {
           ) : (
             <ul className={localStyles.list}>
               <div className={localStyles.resourceTree}>
-                <ListProjectItem
-                  context={this.props.context}
-                  listDatasetsService={this.props.listDatasetsService}
-                  listTablesService={this.props.listTablesService}
-                  listModelsService={this.props.listModelsService}
-                />
+                <ListProjectItem context={this.props.context} />
               </div>
               <div className={showSearchResults}>
                 {isLoadingSearch ? (

--- a/jupyterlab_bigquery/src/components/list_items_panel/search_bar.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/search_bar.tsx
@@ -36,6 +36,7 @@ const searchStyle = stylesheet({
     fontFamily: 'var(--jp-ui-font-family)',
     fontSize: 'var(--jp-ui-font-size1)',
     minWidth: 0,
+    textOverflow: 'ellipsis',
   },
 });
 

--- a/jupyterlab_bigquery/src/components/list_items_panel/service/list_items.ts
+++ b/jupyterlab_bigquery/src/components/list_items_panel/service/list_items.ts
@@ -12,6 +12,7 @@ export interface Project {
   name: string;
   datasets: {};
   datasetIds: [];
+  error?: string;
 }
 
 export interface Dataset {
@@ -22,16 +23,24 @@ export interface Dataset {
   models: {};
   modelIds: [];
   projectId: string;
+  parent: string;
+  type: string;
 }
 
 export interface Table {
   id: string;
   name: string;
+  type: string;
   datasetId: string;
+  parent: string;
 }
 
 export interface Model {
   id: string;
+  name: string;
+  datasetId: string;
+  parent: string;
+  type: string;
 }
 
 export class ListProjectsService {

--- a/jupyterlab_bigquery/src/index.ts
+++ b/jupyterlab_bigquery/src/index.ts
@@ -10,12 +10,7 @@ import { INotebookTracker } from '@jupyterlab/notebook';
 import * as QueryEditorInCellWidgetsExport from './components/query_editor/query_editor_incell/query_editor_incell_widget';
 
 import ListItemsWidget from './components/list_items_panel/list_tree_item_widget';
-import {
-  ListProjectsService,
-  ListDatasetsService,
-  ListTablesService,
-  ListModelsService,
-} from './components/list_items_panel/service/list_items';
+import { ListProjectsService } from './components/list_items_panel/service/list_items';
 import { WidgetManager } from './utils/widgetManager/widget_manager';
 import { ReduxReactWidget } from './utils/widgetManager/redux_react_widget';
 
@@ -32,9 +27,6 @@ async function activate(
     notebookTrack: notebookTrack,
   };
   const listProjectsService = new ListProjectsService();
-  const listDatasetsService = new ListDatasetsService();
-  const listTablesService = new ListTablesService();
-  const listModelsService = new ListModelsService();
   manager.launchWidget(
     ListItemsWidget,
     'left',
@@ -42,13 +34,7 @@ async function activate(
     (widget: ReduxReactWidget) => {
       widget.addClass('jp-BigQueryIcon');
     },
-    [
-      listProjectsService,
-      listDatasetsService,
-      listTablesService,
-      listModelsService,
-      context,
-    ],
+    [listProjectsService, context],
     { rank: 100 }
   );
 


### PR DESCRIPTION
## Refactor Tree
Refactor the data tree in 'list_tree_item.tsx' and the search results in 'list_search_results.tsx'. The files now use class inheritance to be more self-contained and to prevent repetitive code between the files. Functionality of both files is identical to before refactoring (no features added).

## Refreshing
Create refreshing feature for the data tree in 'list_tree_panel.tsx'. Refreshing can be triggered for the whole panel, or for individual projects/datasets via their context menu.

![image](https://user-images.githubusercontent.com/39741440/89674798-bd4fea00-d8b6-11ea-9bd3-38da5c3cd891.png)

### Minor UI Changes
Also change header styling in 'list_tree_panel.tsx' to hide button overflow text with ellipsis instead of wrapping. Add tooltips to display the full title of buttons even when overflowed.

![image](https://user-images.githubusercontent.com/39741440/89675022-38b19b80-d8b7-11ea-8490-3eeef53b51b0.png)
