### PR TITLE
[Optimizer] create study conditional parameters

### DIFF
--- a/jupyterlab_caip_optimizer/src/components/create_study/index.spec.tsx
+++ b/jupyterlab_caip_optimizer/src/components/create_study/index.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createDropdown, DropdownItem, CreateStudy } from '.';
+import { createDropdown, CreateStudy } from '.';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import * as Types from '../../types';
@@ -12,6 +12,7 @@ import {
 import { proxyUrl, createStudyUrl } from '../../utils/urls';
 import { fakeStudy, cleanFakeStudyName } from '../../service/test-constants';
 import userEvent from '@testing-library/user-event';
+import { DropdownItem } from './types';
 
 const server = setupServer();
 

--- a/jupyterlab_caip_optimizer/src/components/create_study/index.tsx
+++ b/jupyterlab_caip_optimizer/src/components/create_study/index.tsx
@@ -129,17 +129,21 @@ const temporaryParametersToSpecs = (
       switch (parentSpec.type) {
         case 'CATEGORICAL':
           // TODO: fixing typings
-          (spec as any).parentCategoricalValues = parent.validFor;
+          (spec as any).parentCategoricalValues = { values: parent.validFor };
           break;
         case 'DISCRETE':
-          (spec as any).parentDiscreteValues = parent.validFor.map(
-            stringValue => parseInt(stringValue, 10)
-          );
+          (spec as any).parentDiscreteValues = {
+            values: parent.validFor.map(stringValue =>
+              parseInt(stringValue, 10)
+            ),
+          };
           break;
         case 'INTEGER':
-          (spec as any).parentIntValues = parent.validFor.map(stringValue =>
-            parseInt(stringValue, 10)
-          );
+          (spec as any).parentIntValues = {
+            values: parent.validFor.map(stringValue =>
+              parseInt(stringValue, 10)
+            ),
+          };
           break;
       }
     }

--- a/jupyterlab_caip_optimizer/src/components/create_study/parameter_type_inputs.tsx
+++ b/jupyterlab_caip_optimizer/src/components/create_study/parameter_type_inputs.tsx
@@ -7,7 +7,13 @@ import {
   TemporaryParameterChildMetadata,
   TemporaryParentParameter,
 } from './types';
-import { TextField, Grid, FormControlLabel, Checkbox } from '@material-ui/core';
+import {
+  TextField,
+  Grid,
+  FormControlLabel,
+  Checkbox,
+  Typography,
+} from '@material-ui/core';
 import { Autocomplete } from '@material-ui/lab';
 import { getOptions } from './utils';
 
@@ -64,6 +70,16 @@ export const ParameterParentInput: React.FC<{
               getOptionLabel={(parameter: string | TemporaryParentParameter) =>
                 typeof parameter === 'string' ? parameter : parameter.name
               }
+              // for testing
+              renderOption={(parameter: string | TemporaryParentParameter) => {
+                const option =
+                  typeof parameter === 'string' ? parameter : parameter.name;
+                return (
+                  <Typography noWrap data-testid={`parent-${option}`}>
+                    {option}
+                  </Typography>
+                );
+              }}
               fullWidth
               renderInput={params => (
                 <TextField
@@ -96,6 +112,12 @@ export const ParameterParentInput: React.FC<{
                 id="parentSelect"
                 options={getOptions(parent)}
                 getOptionLabel={option => option}
+                // for testing
+                renderOption={option => (
+                  <Typography noWrap data-testid={`parentValue-${option}`}>
+                    {option}
+                  </Typography>
+                )}
                 value={metadata.validFor}
                 filterSelectedOptions
                 renderInput={params => (

--- a/jupyterlab_caip_optimizer/src/components/create_study/parameter_type_inputs.tsx
+++ b/jupyterlab_caip_optimizer/src/components/create_study/parameter_type_inputs.tsx
@@ -4,13 +4,12 @@ import {
   TemporaryParameterDiscreteMetadata,
   TemporaryParameterCategoricalMetadata,
   TemporaryParameterIntegerMetadata,
-} from '.';
-import { TextField, Grid } from '@material-ui/core';
-
-type BaseInput<T> = {
-  value: T;
-  onChange?: (value: T) => void;
-};
+  TemporaryParameterChildMetadata,
+  TemporaryParentParameter,
+} from './types';
+import { TextField, Grid, FormControlLabel, Checkbox } from '@material-ui/core';
+import { Autocomplete } from '@material-ui/lab';
+import { getOptions } from './utils';
 
 function change<T>(currentValue: T, set: (value: T) => void) {
   return (valueObj: Partial<T>) => {
@@ -21,9 +20,126 @@ function change<T>(currentValue: T, set: (value: T) => void) {
   };
 }
 
-export const ParameterNumberInput: React.FC<BaseInput<
-  TemporaryParameterDoubleMetadata | TemporaryParameterIntegerMetadata
->> = ({ value, onChange }) => {
+const defaultOption = 'None';
+
+export const ParameterParentInput: React.FC<{
+  parentParameters: TemporaryParentParameter[];
+  metadata?: TemporaryParameterChildMetadata;
+  onChange: (metadata: TemporaryParameterChildMetadata) => void;
+}> = ({ parentParameters, metadata, onChange }) => {
+  // TODO: not working all the time
+  // Default to true if there is parent metadata
+  const [editing, setEditing] = React.useState(!!metadata);
+  const parent: TemporaryParentParameter | undefined = metadata
+    ? parentParameters.find(parameter => parameter.name === metadata.name)
+    : undefined;
+
+  const options: (string | TemporaryParentParameter)[] = [
+    defaultOption,
+    ...parentParameters,
+  ];
+
+  return (
+    <>
+      <Grid item xs={12}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              id="isConditional"
+              name="isConditional"
+              checked={editing}
+              onChange={event => setEditing(event.target.checked)}
+            />
+          }
+          label="This is a conditional (child) parameter"
+          disabled={parentParameters.length === 0}
+        />
+      </Grid>
+      {editing && (
+        <>
+          <Grid item xs={12}>
+            <Autocomplete
+              id="parentParameter"
+              options={options}
+              getOptionLabel={(parameter: string | TemporaryParentParameter) =>
+                typeof parameter === 'string' ? parameter : parameter.name
+              }
+              fullWidth
+              renderInput={params => (
+                <TextField
+                  {...params}
+                  label="Parent Parameter"
+                  variant="outlined"
+                />
+              )}
+              onChange={(
+                event,
+                newValue: string | TemporaryParentParameter
+              ) => {
+                // if it is the default value do not set the parent
+                if (typeof newValue === 'string') {
+                  onChange(undefined);
+                } else {
+                  onChange({
+                    name: newValue.name,
+                    validFor: [],
+                  });
+                }
+              }}
+              {...(parent ? { value: parent } : { value: defaultOption })}
+            />
+          </Grid>
+          {!!parent && (
+            <Grid item xs={12}>
+              <Autocomplete
+                multiple
+                id="parentSelect"
+                options={getOptions(parent)}
+                getOptionLabel={option => option}
+                value={metadata.validFor}
+                filterSelectedOptions
+                renderInput={params => (
+                  <TextField
+                    {...params}
+                    variant="outlined"
+                    label="Parent Values"
+                    placeholder="Valid For"
+                  />
+                )}
+                onChange={(event, nextValue) =>
+                  onChange({
+                    ...metadata,
+                    validFor: nextValue,
+                  })
+                }
+              />
+            </Grid>
+          )}
+        </>
+      )}
+    </>
+  );
+};
+
+type ParentBaseInput<T> = {
+  metadata: T;
+  onChange: (metadata: T) => void;
+  parentParameters: TemporaryParentParameter[];
+  parentMetadata: TemporaryParameterChildMetadata;
+  onChangeParentMetadata: (
+    parentMetadata: TemporaryParameterChildMetadata
+  ) => void;
+};
+
+export const ParameterNumberInput: React.FC<ParentBaseInput<
+  TemporaryParameterIntegerMetadata | TemporaryParameterDoubleMetadata
+>> = ({
+  metadata,
+  onChange,
+  parentParameters,
+  parentMetadata,
+  onChangeParentMetadata,
+}) => {
   return (
     <>
       {/* NOTE: this continues to use the grid layout from parameter list */}
@@ -34,9 +150,9 @@ export const ParameterNumberInput: React.FC<BaseInput<
           variant="outlined"
           label="Min Value"
           fullWidth
-          value={value.minValue}
+          value={metadata.minValue}
           onChange={event =>
-            change(value, onChange)({ minValue: event.target.value })
+            change(metadata, onChange)({ minValue: event.target.value })
           }
         />
       </Grid>
@@ -47,32 +163,50 @@ export const ParameterNumberInput: React.FC<BaseInput<
           variant="outlined"
           label="Max Value"
           fullWidth
-          value={value.maxValue}
+          value={metadata.maxValue}
           onChange={event =>
-            change(value, onChange)({ maxValue: event.target.value })
+            change(metadata, onChange)({ maxValue: event.target.value })
           }
         />
       </Grid>
+      <ParameterParentInput
+        parentParameters={parentParameters}
+        metadata={parentMetadata}
+        onChange={onChangeParentMetadata}
+      />
     </>
   );
 };
 
-export const ParameterListInput: React.FC<BaseInput<
+export const ParameterListInput: React.FC<ParentBaseInput<
   TemporaryParameterDiscreteMetadata | TemporaryParameterCategoricalMetadata
->> = ({ value, onChange }) => {
+>> = ({
+  metadata,
+  onChange,
+  parentParameters,
+  parentMetadata,
+  onChangeParentMetadata,
+}) => {
   return (
-    <Grid item xs={12}>
-      <TextField
-        id="parameterListValue"
-        required
-        variant="outlined"
-        label="List of possible values (comma separated)"
-        fullWidth
-        value={value.valueList.join(',')}
-        onChange={event =>
-          onChange({ valueList: event.target.value.split(',') })
-        }
+    <>
+      <Grid item xs={12}>
+        <TextField
+          id="parameterListValue"
+          required
+          variant="outlined"
+          label="List of possible values (comma separated)"
+          fullWidth
+          value={metadata.valueList.join(',')}
+          onChange={event =>
+            onChange({ valueList: event.target.value.split(',') })
+          }
+        />
+      </Grid>
+      <ParameterParentInput
+        parentParameters={parentParameters}
+        metadata={parentMetadata}
+        onChange={onChangeParentMetadata}
       />
-    </Grid>
+    </>
   );
 };

--- a/jupyterlab_caip_optimizer/src/components/create_study/types.ts
+++ b/jupyterlab_caip_optimizer/src/components/create_study/types.ts
@@ -1,0 +1,87 @@
+export interface DropdownItem {
+  value: string;
+  label: string;
+}
+
+export type TemporaryParameterChildMetadata = {
+  name: string;
+  validFor: string[];
+};
+
+export type TemporaryParameterParentMetadata = {
+  name: string;
+  // Valid for certain parent values
+  validFor: string[];
+};
+
+export type TemporaryParameterBase = {
+  name: string;
+  parent?: TemporaryParameterChildMetadata;
+};
+
+export type TemporaryParameterUnspecifiedMetadata = {};
+export type TemporaryParameterUnspecified = TemporaryParameterBase & {
+  type: 'PARAMETER_TYPE_UNSPECIFIED';
+  metadata: TemporaryParameterUnspecifiedMetadata;
+};
+
+export type TemporaryParameterDoubleMetadata = {
+  minValue: string;
+  maxValue: string;
+};
+export type TemporaryParameterDouble = TemporaryParameterBase &
+  TemporaryParameterChildMetadata & {
+    type: 'DOUBLE';
+    metadata: TemporaryParameterDoubleMetadata;
+  };
+
+export type TemporaryParameterIntegerMetadata = {
+  minValue: string;
+  maxValue: string;
+};
+export type TemporaryParameterInteger = TemporaryParameterBase &
+  TemporaryParameterChildMetadata & {
+    type: 'INTEGER';
+    metadata: TemporaryParameterIntegerMetadata;
+    children?: TemporaryParameterParentMetadata[];
+  };
+
+export type TemporaryParameterDiscreteMetadata = {
+  // NOTE: this is a string list not a number list!
+  valueList: string[];
+};
+export type TemporaryParameterDiscrete = TemporaryParameterBase &
+  TemporaryParameterChildMetadata & {
+    type: 'DISCRETE';
+    metadata: TemporaryParameterDiscreteMetadata;
+    children?: TemporaryParameterParentMetadata[];
+  };
+
+export type TemporaryParameterCategoricalMetadata = {
+  valueList: string[];
+};
+export type TemporaryParameterCategorical = TemporaryParameterBase &
+  TemporaryParameterChildMetadata & {
+    type: 'CATEGORICAL';
+    metadata: TemporaryParameterCategoricalMetadata;
+    children?: TemporaryParameterParentMetadata[];
+  };
+
+export type TemporaryParameterMetadata =
+  | TemporaryParameterUnspecifiedMetadata
+  | TemporaryParameterDoubleMetadata
+  | TemporaryParameterIntegerMetadata
+  | TemporaryParameterDiscreteMetadata
+  | TemporaryParameterCategoricalMetadata;
+
+export type TemporaryParentParameter =
+  | TemporaryParameterInteger
+  | TemporaryParameterDiscrete
+  | TemporaryParameterCategorical;
+
+export type TemporaryParameter =
+  | TemporaryParameterUnspecified
+  | TemporaryParameterDouble
+  | TemporaryParameterInteger
+  | TemporaryParameterDiscrete
+  | TemporaryParameterCategorical;

--- a/jupyterlab_caip_optimizer/src/components/create_study/types.ts
+++ b/jupyterlab_caip_optimizer/src/components/create_study/types.ts
@@ -14,6 +14,7 @@ export type TemporaryParameterParentMetadata = {
   validFor: string[];
 };
 
+// TODO: add id for children with same name, but different parents
 export type TemporaryParameterBase = {
   name: string;
   parent?: TemporaryParameterChildMetadata;

--- a/jupyterlab_caip_optimizer/src/components/create_study/utils.ts
+++ b/jupyterlab_caip_optimizer/src/components/create_study/utils.ts
@@ -1,0 +1,28 @@
+import { TemporaryParameter, TemporaryParentParameter } from './types';
+
+export function isParentParameter(
+  parameter: TemporaryParameter
+): parameter is TemporaryParentParameter {
+  return (
+    parameter.type === 'CATEGORICAL' ||
+    parameter.type === 'DISCRETE' ||
+    parameter.type === 'INTEGER'
+  );
+}
+
+export function getOptions(parameter: TemporaryParentParameter): string[] {
+  switch (parameter.type) {
+    case 'DISCRETE':
+    case 'CATEGORICAL':
+      return parameter.metadata.valueList;
+    case 'INTEGER': {
+      const list: string[] = [];
+      const min = parseInt(parameter.metadata.minValue, 10);
+      const max = parseInt(parameter.metadata.maxValue, 10);
+      for (let i = min; i < max; ++i) {
+        list.push(i.toString(10));
+      }
+      return list;
+    }
+  }
+}

--- a/jupyterlab_caip_optimizer/src/components/create_study/utils.ts
+++ b/jupyterlab_caip_optimizer/src/components/create_study/utils.ts
@@ -19,7 +19,7 @@ export function getOptions(parameter: TemporaryParentParameter): string[] {
       const list: string[] = [];
       const min = parseInt(parameter.metadata.minValue, 10);
       const max = parseInt(parameter.metadata.maxValue, 10);
-      for (let i = min; i < max; ++i) {
+      for (let i = min; i <= max; ++i) {
         list.push(i.toString(10));
       }
       return list;

--- a/jupyterlab_caip_optimizer/src/setupTests.ts
+++ b/jupyterlab_caip_optimizer/src/setupTests.ts
@@ -38,6 +38,21 @@ beforeAll(() => {
     }
     return originalError(...args);
   });
+
+  // https://github.com/mui-org/material-ui/issues/15726#issuecomment-493124813
+  // TODO: remove upgrading to jest v26
+  global.document.createRange = () => ({
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    setStart: () => {},
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    setEnd: () => {},
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    commonAncestorContainer: {
+      nodeName: 'BODY',
+      ownerDocument: document,
+    },
+  });
 });
 
 afterAll(() => {

--- a/jupyterlab_caip_optimizer/src/types.ts
+++ b/jupyterlab_caip_optimizer/src/types.ts
@@ -103,15 +103,15 @@ export type ParameterSpecParent =
     }
   | {};
 
-export type UnspecifiedParameter = ParameterBase &
-  ParameterSpecParent & {
-    type: 'PARAMETER_TYPE_UNSPECIFIED';
-  };
-
-export type DoubleParameterSpec = ParameterSpecBase & {
-  type: 'DOUBLE';
-  doubleValueSpec: DoubleValueSpec;
+export type UnspecifiedParameter = ParameterBase & {
+  type: 'PARAMETER_TYPE_UNSPECIFIED';
 };
+
+export type DoubleParameterSpec = ParameterSpecBase &
+  ParameterSpecParent & {
+    type: 'DOUBLE';
+    doubleValueSpec: DoubleValueSpec;
+  };
 
 export type IntegerParameterSpec = ParameterSpecBase &
   ParameterSpecChildren &


### PR DESCRIPTION
# Description

- User can enable a conditional parameter
  - User then selects the parent parameter (only valid parameters are shown, ie can not be the current parameter, and must be a categorical, integer or discrete parameter spec)
   - User then selects the valid options that the parameter shows up for
- **Should I show the parameter tree (like the one on the study details page)?** It would be easy for me to add.

# Images

![image](https://user-images.githubusercontent.com/12939414/89470210-7805ae00-d738-11ea-8b4e-bb931512150d.png)
![image](https://user-images.githubusercontent.com/12939414/89470243-92d82280-d738-11ea-8c89-dad627706aad.png)
![image](https://user-images.githubusercontent.com/12939414/89470279-aedbc400-d738-11ea-8cdd-73833a962092.png)
**Boom - Created study!**
![image](https://user-images.githubusercontent.com/12939414/89470324-c61ab180-d738-11ea-8e5a-aae5cd777fe0.png)

