### PR TITLE
[HardwareConfiguration] Prepopulate scaling form with user's current configuration, adding in…

### DIFF
--- a/jupyterlab_gcedetails/src/components/confirmation_page.tsx
+++ b/jupyterlab_gcedetails/src/components/confirmation_page.tsx
@@ -60,8 +60,8 @@ export const STYLES = stylesheet({
   },
 });
 
-const INFO_MESSAGE =
-  'Updating your configuration will take 5-10 minutes. During this time you will not be able to access your notebook instance.';
+const INFO_MESSAGE = `Updating your configuration will take 5-10 minutes. During this time you will not be able to access your notebook instance.
+  If you have chosen to attach GPUs to your instance, the NVIDIA GPU driver will be installed automatically on the next startup.`;
 
 function getGpuTypeText(value: string) {
   return ACCELERATOR_TYPES.find(option => option.value === value).text;
@@ -76,7 +76,7 @@ function displayConfiguration(
   return (
     <div>
       <span className={classes(STYLES.title, STYLES.topPadding)}>{title}</span>
-      <div className={STYLES.text}>Machine type: {machineType.text}</div>
+      <div className={STYLES.text}>Machine type: {machineType.description}</div>
       {attachGpu && (
         <div className={STYLES.text}>
           {`GPUs: ${gpuCount} ${getGpuTypeText(gpuType)}`}

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_dialog.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_dialog.tsx
@@ -75,6 +75,7 @@ export class HardwareScalingDialog extends React.Component<Props, State> {
                 hardwareConfiguration: config,
               });
             }}
+            details={details}
           />
         );
       case View.CONFIRMATION:

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_status.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_status.tsx
@@ -111,7 +111,7 @@ export class HardwareScalingStatus extends React.Component<Props, State> {
           this.setState({ status: Status['Reshaping Instance'] });
           break;
         case Status['Reshaping Instance']:
-          await notebookService.setMachineType(machineType.value as string);
+          await notebookService.setMachineType(machineType.name);
           if (attachGpu) {
             await notebookService.setAccelerator(gpuType, gpuCount);
           }

--- a/jupyterlab_gcedetails/src/components/machine_type_select.tsx
+++ b/jupyterlab_gcedetails/src/components/machine_type_select.tsx
@@ -27,7 +27,7 @@ import TextField from '@material-ui/core/TextField';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
-import { Option, TEXT_STYLE } from '../data';
+import { Option, TEXT_STYLE, TEXT_LABEL_STYLE } from '../data';
 
 const STYLES = stylesheet({
   itemGroup: {
@@ -217,6 +217,7 @@ interface NestedSelectProps {
   nestedOptionsList: NestedOptions[];
   onChange?: (value: Option) => void;
   label?: string;
+  value?: Option;
 }
 
 interface NestedSelectState {
@@ -232,7 +233,7 @@ export class NestedSelect extends React.Component<
     super(props);
 
     this.state = {
-      value: props.nestedOptionsList[0].options[0],
+      value: props.value ? props.value : props.nestedOptionsList[0].options[0],
       anchorEl: null,
     };
   }
@@ -270,8 +271,12 @@ export class NestedSelect extends React.Component<
 
     return (
       <div className={STYLES.nestedSelect}>
-        {label && <label>{label}</label>}
+        {/* {label && <label>{label}</label>} */}
         <TextField
+          InputLabelProps={{
+            style: TEXT_LABEL_STYLE,
+          }}
+          label={label}
           className={STYLES.input}
           value={this.displayValue(value)}
           margin="dense"

--- a/jupyterlab_gcedetails/src/components/machine_type_select.tsx
+++ b/jupyterlab_gcedetails/src/components/machine_type_select.tsx
@@ -271,7 +271,6 @@ export class NestedSelect extends React.Component<
 
     return (
       <div className={STYLES.nestedSelect}>
-        {/* {label && <label>{label}</label>} */}
         <TextField
           InputLabelProps={{
             style: TEXT_LABEL_STYLE,

--- a/jupyterlab_gcedetails/src/components/select_input.tsx
+++ b/jupyterlab_gcedetails/src/components/select_input.tsx
@@ -19,7 +19,7 @@ import { stylesheet } from 'typestyle';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import TextField from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
-import { Option, TEXT_STYLE } from '../data';
+import { Option, TEXT_STYLE, TEXT_LABEL_STYLE } from '../data';
 
 interface Props {
   label?: string;
@@ -49,8 +49,12 @@ export function SelectInput(props: Props) {
 
   return (
     <div>
-      {label && <label>{label}</label>}
+      {/* {label && <label>{label}</label>} */}
       <TextField
+        InputLabelProps={{
+          style: TEXT_LABEL_STYLE,
+        }}
+        label={label}
         className={STYLES.select}
         select
         value={value}

--- a/jupyterlab_gcedetails/src/components/select_input.tsx
+++ b/jupyterlab_gcedetails/src/components/select_input.tsx
@@ -49,7 +49,6 @@ export function SelectInput(props: Props) {
 
   return (
     <div>
-      {/* {label && <label>{label}</label>} */}
       <TextField
         InputLabelProps={{
           style: TEXT_LABEL_STYLE,

--- a/jupyterlab_gcedetails/src/data.ts
+++ b/jupyterlab_gcedetails/src/data.ts
@@ -71,23 +71,34 @@ export interface Option {
 }
 
 export interface HardwareConfiguration {
-  machineType: Option;
+  machineType: MachineType;
   attachGpu: boolean;
   gpuType: string;
   gpuCount: string;
+}
+
+export function optionToMachineType(option: Option): MachineType {
+  return {
+    name: option.value as string,
+    description: option.text,
+  };
+}
+
+export function machineTypeToOption(machineType: MachineType): Option {
+  return {
+    value: machineType.name,
+    text: machineType.description,
+    disabled: false,
+  };
 }
 
 export function detailsToHardwareConfiguration(
   details: Details
 ): HardwareConfiguration {
   const { instance, gpu } = details;
-  const machineType: Option = {
-    value: instance.machineType.name,
-    text: instance.machineType.description,
-  };
 
   return {
-    machineType,
+    machineType: instance.machineType,
     attachGpu: Boolean(gpu.name),
     gpuType: gpu.name,
     gpuCount: gpu.count,
@@ -160,6 +171,8 @@ export const ACCELERATOR_COUNTS_1_2_4_8: Option[] = [
   { value: '4', text: '4' },
   { value: '8', text: '8' },
 ];
+
+export const NO_ACCELERATOR = '';
 
 /**
  * AI Platform Machine types.
@@ -343,4 +356,11 @@ export const STYLES = stylesheet({
 export const TEXT_STYLE = {
   fontFamily: BASE_FONT.fontFamily as string,
   fontSize: BASE_FONT.fontSize as number,
+};
+
+export const TEXT_LABEL_STYLE = {
+  ...TEXT_STYLE,
+  fontSize: '15px',
+  paddingRight: '2px',
+  backgroundColor: '#FFFFFF',
 };

--- a/jupyterlab_gcedetails/src/details_widget.tsx
+++ b/jupyterlab_gcedetails/src/details_widget.tsx
@@ -102,6 +102,7 @@ export class VmDetails extends React.Component<Props, State> {
             open={formDisplayed}
             onClose={() => this.setState({ formDisplayed: false })}
             notebookService={notebookService}
+            details={details}
           />
         )}
       </span>


### PR DESCRIPTION
…fo messages and modifying styling

![Screenshot 2020-08-06 at 9 51 59 AM](https://user-images.githubusercontent.com/28398459/89567831-523be000-d7f0-11ea-8b42-7e2e8673bb67.png)

![Screenshot 2020-08-06 at 10 20 00 AM](https://user-images.githubusercontent.com/28398459/89567423-a2667280-d7ef-11ea-8be3-5be8537a8875.png)


This commit:
 - Prepopulates the hardware scaling form with the users current configuration and consequently modifies the machineType variables to be type MachineType in the state of the HardwareScalingForm and Option when used in the select
 - Adds a message informing the user of potential GPU type availability restrictions 
 - Adds a message informing the user that GPU drivers may be installed on machine startup when they request to scale their VM
 - Changes the styling of the hardware scaling form slightly (adding labels and subtitles)