### PR TITLE
[HardwareConfiguration] Restricting gpu types a user can select

### DIFF
--- a/jupyterlab_gcedetails/src/components/confirmation_page.tsx
+++ b/jupyterlab_gcedetails/src/components/confirmation_page.tsx
@@ -28,7 +28,7 @@ import { HardwareConfiguration, ACCELERATOR_TYPES } from '../data';
 import { HardwareConfigurationDescription } from './hardware_scaling_form';
 
 interface Props {
-  formData: HardwareConfiguration;
+  formData?: HardwareConfiguration;
   onDialogClose: () => void;
   currentConfiguration?: HardwareConfiguration;
   onSubmit: () => void;

--- a/jupyterlab_gcedetails/src/components/confirmation_page.tsx
+++ b/jupyterlab_gcedetails/src/components/confirmation_page.tsx
@@ -28,7 +28,7 @@ import { HardwareConfiguration, ACCELERATOR_TYPES } from '../data';
 import { HardwareConfigurationDescription } from './hardware_scaling_form';
 
 interface Props {
-  formData?: HardwareConfiguration;
+  formData: HardwareConfiguration;
   onDialogClose: () => void;
   currentConfiguration?: HardwareConfiguration;
   onSubmit: () => void;

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
@@ -87,9 +87,6 @@ export const STYLES = stylesheet({
   description: {
     paddingBottom: '10px',
   },
-  infoMessage: {
-    margin: '20px 16px 0px 16px',
-  },
   topPadding: {
     paddingTop: '10px',
   },

--- a/jupyterlab_gcedetails/src/data.ts
+++ b/jupyterlab_gcedetails/src/data.ts
@@ -80,8 +80,94 @@ export interface Option {
 export interface HardwareConfiguration {
   machineType: MachineType;
   attachGpu: boolean;
-  gpuType: string;
+  gpuType: string; // as Notebooks API AcceleratorType enum values
   gpuCount: string;
+}
+
+/**
+ * AI Platform Accelerator types.
+ * https://cloud.google.com/ai-platform/training/docs/using-gpus#compute-engine-machine-types-with-gpu
+ */
+export const ACCELERATOR_TYPES: Option[] = [
+  { value: 'NVIDIA_TESLA_K80', text: 'NVIDIA Tesla K80' },
+  { value: 'NVIDIA_TESLA_P4', text: 'NVIDIA Tesla P4' },
+  { value: 'NVIDIA_TESLA_P100', text: 'NVIDIA Tesla P100' },
+  { value: 'NVIDIA_TESLA_T4', text: 'NVIDIA Tesla T4' },
+  { value: 'NVIDIA_TESLA_V100', text: 'NVIDIA Tesla V100' },
+];
+
+/**
+ * AI Platform Accelerator counts.
+ * https://cloud.google.com/ai-platform/training/docs/using-gpus
+ */
+export const ACCELERATOR_COUNTS_1_2_4_8: Option[] = [
+  { value: '1', text: '1' },
+  { value: '2', text: '2' },
+  { value: '4', text: '4' },
+  { value: '8', text: '8' },
+];
+
+export const NO_ACCELERATOR = '';
+
+/**
+ * Convert nvidia-smi product_name type to match the AcceleratorType
+ * enums that are used in the Notebooks API:
+ * https://cloud.google.com/ai-platform/notebooks/docs/reference/rest/v1beta1/projects.locations.instances#AcceleratorType
+ */
+function nvidiaNameToEnum(name: string): string {
+  const accelerator = ACCELERATOR_TYPES.find(accelerator =>
+    accelerator.text.endsWith(name)
+  );
+
+  return accelerator ? NO_ACCELERATOR : (accelerator.value as string);
+}
+
+/**
+ * Format gcloud compute acceleratorType to match the AcceleratorType
+ * enums that are used in the Notebooks API:
+ * https://cloud.google.com/ai-platform/notebooks/docs/reference/rest/v1beta1/projects.locations.instances#AcceleratorType
+ */
+function acceleratorNameToEnum(name: string): string {
+  return name.toUpperCase().replace(/-/g, '_');
+}
+
+export function getGpuTypeOptionsList(
+  accelerators: Accelerator[],
+  cpuPlatform: string
+): Option[] {
+  // For more information on gpu restrictions see: https://cloud.google.com/compute/docs/gpus#restrictions
+  accelerators = accelerators.filter(
+    accelerator =>
+      // filter out virtual workstation accelerator types
+      !accelerator.name.endsWith('-vws') &&
+      // a minimum cpu platform of Intel Skylake or later does not currently support the k80 gpu
+      !(
+        accelerator.name === 'nvidia-tesla-k80' &&
+        cpuPlatform === 'Intel Skylake'
+      )
+  );
+
+  return accelerators.map(accelerator => ({
+    value: acceleratorNameToEnum(accelerator.name),
+    text: accelerator.description,
+  }));
+}
+
+export function getGpuCountOptionsList(
+  accelerators: Accelerator[],
+  acceleratorName: string
+): Option[] {
+  if (acceleratorName === NO_ACCELERATOR) return ACCELERATOR_COUNTS_1_2_4_8;
+
+  const accelerator = accelerators.find(
+    accelerator => acceleratorNameToEnum(accelerator.name) === acceleratorName
+  );
+  return accelerator
+    ? ACCELERATOR_COUNTS_1_2_4_8.slice(
+        0,
+        Math.log(accelerator.maximumCardsPerInstance) / Math.log(2) + 1
+      )
+    : ACCELERATOR_COUNTS_1_2_4_8;
 }
 
 export function optionToMachineType(option: Option): MachineType {
@@ -107,8 +193,8 @@ export function detailsToHardwareConfiguration(
   return {
     machineType: instance.machineType,
     attachGpu: Boolean(gpu.name),
-    gpuType: gpu.name,
-    gpuCount: gpu.count,
+    gpuType: nvidiaNameToEnum(gpu.name),
+    gpuCount: gpu.name ? gpu.count : NO_ACCELERATOR,
   };
 }
 
@@ -154,32 +240,6 @@ export const REFRESHABLE_MAPPED_ATTRIBUTES = [
 ];
 
 MAPPED_ATTRIBUTES.push(...REFRESHABLE_MAPPED_ATTRIBUTES);
-
-/**
- * AI Platform Accelerator types.
- * https://cloud.google.com/ai-platform/training/docs/using-gpus#compute-engine-machine-types-with-gpu
- */
-export const ACCELERATOR_TYPES: Option[] = [
-  { value: '', text: 'None' },
-  { value: 'NVIDIA_TESLA_K80', text: 'NVIDIA Tesla K80' },
-  { value: 'NVIDIA_TESLA_P4', text: 'NVIDIA Tesla P4' },
-  { value: 'NVIDIA_TESLA_P100', text: 'NVIDIA Tesla P100' },
-  { value: 'NVIDIA_TESLA_T4', text: 'NVIDIA Tesla T4' },
-  { value: 'NVIDIA_TESLA_V100', text: 'NVIDIA Tesla V100' },
-];
-
-/**
- * AI Platform Accelerator counts.
- * https://cloud.google.com/ai-platform/training/docs/using-gpus
- */
-export const ACCELERATOR_COUNTS_1_2_4_8: Option[] = [
-  { value: '1', text: '1' },
-  { value: '2', text: '2' },
-  { value: '4', text: '4' },
-  { value: '8', text: '8' },
-];
-
-export const NO_ACCELERATOR = '';
 
 /**
  * AI Platform Machine types.


### PR DESCRIPTION
This PR restricts the GPU types and counts a user can select from on the hardware scaling form:
 - The attach GPU option is disabled if the user has selected an N1 general-purpose machine type
 - Only the GPUs available in the user's project/zone are displayed as options
 - Only the valid count values are displayed for the selected GPU type
 - If fetching the available GPUs from gcloud fails falls back on to using the master GPU type and count lists as options in the dropdowns

https://screencast.googleplex.com/cast/NTUyNDMwNDcwNTg4MDA2NHwwZWQ1ZDg2ZC1iYQ

Resolves #154 