### PR TITLE
[BigQuery] Create query history feature

### DIFF
--- a/jupyterlab_bigquery/jupyterlab_bigquery/__init__.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/__init__.py
@@ -5,6 +5,7 @@ from notebook.utils import url_path_join
 from jupyterlab_bigquery.list_items_handler import Handlers
 from jupyterlab_bigquery.details_handler import DatasetDetailsHandler, TablePreviewHandler, TableDetailsHandler, ViewDetailsHandler, ModelDetailsHandler
 from jupyterlab_bigquery.version import VERSION
+from jupyterlab_bigquery.query_history_handler import QueryHistoryHandler, GetQueryDetailsHandler
 from jupyterlab_bigquery.pagedAPI_handler import PagedQueryHandler
 from jupyterlab_bigquery.query_incell_editor import QueryIncellEditor, _cell_magic
 
@@ -44,7 +45,9 @@ def load_jupyter_server_extension(nb_server_app):
         make_endpoint('tablepreview', TablePreviewHandler),
         make_endpoint('viewdetails', ViewDetailsHandler),
         make_endpoint('modeldetails', ModelDetailsHandler),
-        make_endpoint('query', PagedQueryHandler)
+        make_endpoint('query', PagedQueryHandler),
+        make_endpoint('projectQueryHistory', QueryHistoryHandler),
+        make_endpoint('getQueryDetails', GetQueryDetailsHandler)
     ])
 
 def load_ipython_extension(ipython):

--- a/jupyterlab_bigquery/jupyterlab_bigquery/query_history_handler/__init__.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/query_history_handler/__init__.py
@@ -1,0 +1,1 @@
+from .query_history_handler import QueryHistoryHandler, GetQueryDetailsHandler

--- a/jupyterlab_bigquery/jupyterlab_bigquery/query_history_handler/query_history_handler.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/query_history_handler/query_history_handler.py
@@ -1,0 +1,132 @@
+# Lint as: python3
+"""Request handler classes for the extensions."""
+
+import base64
+import json
+import re
+import tornado.gen as gen
+import os
+import math
+
+import json
+import datetime
+
+from collections import namedtuple
+from notebook.base.handlers import APIHandler, app_log
+from google.cloud import bigquery
+
+from jupyterlab_bigquery.version import VERSION
+
+SCOPE = ("https://www.googleapis.com/auth/cloud-platform",)
+
+def create_bigquery_client():
+  return bigquery.Client()
+
+def format_value(value):
+  if value is None:
+    return None
+  elif isinstance(value, bytes):
+    return base64.b64encode(value).__str__()[2:-1]
+  elif isinstance(value, float):
+    if value == float('inf'):
+      return 'Infinity'
+    elif value == float('-inf'):
+      return '-Infinity'
+    elif math.isnan(value):
+      return 'NaN'
+    else:
+      return value
+  elif isinstance(value, datetime.datetime):
+    return json.dumps(value.strftime('%b %e, %G, %l:%M:%S %p'))[1:-1]
+  else:
+    return value.__str__()
+
+def get_table(client, tableRef):
+  try:
+    table_id = client.get_table(tableRef).id
+    return table_id
+  except:
+    return 'Expired temporary table'
+
+def list_jobs(client, project):
+  jobs = list(client.list_jobs(project))
+
+  jobs_list = {}
+  job_ids = {}
+  for job in jobs:
+    if job.job_type != 'query':
+      continue
+    jobs_list[job.job_id] = {
+        'query': job.query,
+        'id': job.job_id,
+        'created': format_value(job.created),
+        'time': json.dumps(job.created.strftime('%l:%M %p'))[1:-1],
+        'errored': True if job.errors else False
+    }
+    curr_date = json.dumps(job.created.strftime('%-m/%-d/%y'))[1:-1]
+    if curr_date in job_ids:
+      job_ids[curr_date].append(job.job_id)
+    else:
+      job_ids[curr_date] = [job.job_id]
+
+  return {'jobs': jobs_list, 'jobIds': job_ids}
+
+def get_job_details(client, job_id):
+  job = client.get_job(job_id)
+  
+  job_details = {
+      'query': job.query,
+      'id': job_id,
+      'user': job.user_email,
+      'location': job.location,
+      'created': format_value(job.created),
+      'started': format_value(job.started),
+      'ended': format_value(job.ended),
+      'duration': (job.ended - job.started).total_seconds(),
+      'bytesProcessed': job.estimated_bytes_processed,
+      'priority': job.priority,
+      'destination': get_table(client, job.destination),
+      'useLegacySql': job.use_legacy_sql,
+      'state': job.state,
+      'errors': job.errors,
+      'errorResult': job.error_result,
+      'from_cache': job.cache_hit,
+      'project': job.project,
+  }
+
+  return job_details
+
+
+class QueryHistoryHandler(APIHandler):
+  """Handles requests for view details."""
+  bigquery_client = None
+
+  @gen.coroutine
+  def post(self, *args, **kwargs):
+    try:
+      self.bigquery_client = create_bigquery_client()
+      post_body = self.get_json_body()
+
+      self.finish(list_jobs(self.bigquery_client, post_body['projectId']))
+
+    except Exception as e:
+      app_log.exception(str(e))
+      self.set_status(500, str(e))
+      self.finish({'error': {'message': str(e)}})
+
+class GetQueryDetailsHandler(APIHandler):
+  """Handles requests for table metadata."""
+  bigquery_client = None
+
+  @gen.coroutine
+  def post(self, *args, **kwargs):
+    try:
+      self.bigquery_client = create_bigquery_client()
+      post_body = self.get_json_body()
+
+      self.finish(get_job_details(self.bigquery_client, post_body['jobId']))
+
+    except Exception as e:
+      app_log.exception(str(e))
+      self.set_status(500, str(e))
+      self.finish({'error': {'message': str(e)}})

--- a/jupyterlab_bigquery/jupyterlab_bigquery/tests/query_history_handler_test.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/tests/query_history_handler_test.py
@@ -1,0 +1,135 @@
+# Lint as: python3
+"""Tests for details panel handlers."""
+import unittest
+import datetime
+from unittest.mock import Mock, MagicMock, patch
+
+from google.cloud.bigquery.job import QueryJob
+from jupyterlab_bigquery.query_history_handler.query_history_handler import get_table, list_jobs, get_job_details
+
+
+class TestQueryHistory(unittest.TestCase):
+
+  def testGetTable(self):
+    mock_table = Mock()
+    mock_table.id = 'dummy_table'
+
+    mock_table_ref = Mock()
+    mock_table_ref.id = 'dummy_table'
+
+    mock_client = Mock()
+    mock_client.get_table = MagicMock(return_value=mock_table)
+
+    wanted = 'dummy_table'
+
+    got = get_table(mock_client, mock_table_ref)
+    self.assertEqual(wanted, got)
+
+  def testListJobs(self):
+    mock_job = Mock(job_type='query',
+                    query='SELECT * FROM *',
+                    job_id='dummy_job',
+                    created=datetime.datetime(2020,
+                                              7,
+                                              14,
+                                              13,
+                                              23,
+                                              45,
+                                              67,
+                                              tzinfo=None),
+                    errors='error')
+
+    gcp_jobs = [mock_job]
+
+    mock_client = Mock()
+    mock_client.list_jobs = MagicMock(return_value=gcp_jobs)
+
+    wanted = {
+        'jobs': {
+            'dummy_job': {
+                'query': 'SELECT * FROM *',
+                'id': 'dummy_job',
+                'created': 'Jul 14, 2020,  1:23:45 PM',
+                'time': ' 1:23 PM',
+                'errored': True,
+            }
+        },
+        'jobIds': {
+            '7/14/20': ['dummy_job']
+        },
+    }
+
+    got = list_jobs(mock_client, 'dummy_dataset1')
+    self.assertEqual(wanted, got)
+
+  def testGetJobDetails(self):
+    mock_table = Mock(id='dummy_table')
+    mock_table_ref = Mock(id='dummy_table')
+
+    mock_job = Mock(query='SELECT * FROM *',
+                    user_email='dummy_email',
+                    location='US',
+                    created=datetime.datetime(2020,
+                                              7,
+                                              14,
+                                              13,
+                                              23,
+                                              45,
+                                              67,
+                                              tzinfo=None),
+                    started=datetime.datetime(2020,
+                                              7,
+                                              14,
+                                              13,
+                                              23,
+                                              45,
+                                              67,
+                                              tzinfo=None),
+                    ended=datetime.datetime(2020,
+                                            7,
+                                            14,
+                                            13,
+                                            23,
+                                            45,
+                                            67,
+                                            tzinfo=None),
+                    estimated_bytes_processed=1,
+                    priority=1,
+                    destination=mock_table_ref,
+                    use_legacy_sql=False,
+                    state='Done',
+                    errors=None,
+                    error_result=None,
+                    cache_hit=None,
+                    project=None)
+
+    mock_client = Mock()
+    mock_client.get_table = MagicMock(return_value=mock_table)
+    mock_client.get_job = MagicMock(return_value=mock_job)
+
+    wanted = {
+        'query': 'SELECT * FROM *',
+        'id': 'dummy_job',
+        'user': 'dummy_email',
+        'location': 'US',
+        'created': 'Jul 14, 2020,  1:23:45 PM',
+        'started': 'Jul 14, 2020,  1:23:45 PM',
+        'ended': 'Jul 14, 2020,  1:23:45 PM',
+        'duration': 0.0,
+        'bytesProcessed': 1,
+        'priority': 1,
+        'destination': 'dummy_table',
+        'useLegacySql': False,
+        'state': 'Done',
+        'errors': None,
+        'errorResult': None,
+        'from_cache': None,
+        'project': None,
+    }
+
+    got = get_job_details(mock_client, 'dummy_job')
+    self.assertEqual(wanted, got)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/jupyterlab_bigquery/src/components/details_panel/table_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_panel.tsx
@@ -24,7 +24,7 @@ interface DetailRow {
   value: string | number;
 }
 
-function formatBytes(numBytes, numDecimals = 2) {
+export function formatBytes(numBytes, numDecimals = 2) {
   if (numBytes === 0) return '0 Bytes';
   const d = Math.floor(Math.log(numBytes) / Math.log(1024));
   return (

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
@@ -19,6 +19,8 @@ import {
   DataTree,
   GetProjectService,
 } from './service/list_items';
+import { QueryHistoryService } from '../query_history/service/query_history';
+import { QueryHistoryWidget } from '../query_history/query_history_widget';
 import ListProjectItem from './list_tree_item';
 import { WidgetManager } from '../../utils/widgetManager/widget_manager';
 import ListSearchResults from './list_search_results';
@@ -169,14 +171,26 @@ const localStyles = stylesheet({
     height: '100%',
     //...BASE_FONT,
     ...csstips.vertical,
-    marginTop: '5px',
-    marginBottom: '5px',
   },
   enableSearch: {
     ...csstips.flex,
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  queryHistory: {
+    fontWeight: 600,
+    fontFamily: 'var(--jp-ui-font-family)',
+    fontSize: 'var(--jp-ui-font-size0, 11px)',
+    letterSpacing: '1px',
+    margin: 0,
+    padding: '8px 12px',
+    textTransform: 'uppercase',
+    '&:hover': {
+      backgroundColor: '#e8e8e8',
+      opacity: 1,
+      cursor: 'pointer',
+    },
   },
 });
 
@@ -300,6 +314,17 @@ class ListItemsPanel extends React.Component<Props, State> {
     this.getProjects();
   };
 
+  openQueryHistory = async () => {
+    const service = new QueryHistoryService();
+    WidgetManager.getInstance().launchWidget(
+      QueryHistoryWidget,
+      'main',
+      'QueryHistoryWidget',
+      undefined,
+      [service]
+    );
+  };
+
   async componentWillMount() {
     try {
       //empty
@@ -419,6 +444,12 @@ class ListItemsPanel extends React.Component<Props, State> {
               </div>
             </ul>
           )}
+        </div>
+        <div
+          className={localStyles.queryHistory}
+          onClick={this.openQueryHistory}
+        >
+          Query History
         </div>
         <DialogComponent
           header="Requirements to Enable Searching"

--- a/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
+++ b/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
@@ -1,0 +1,284 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Paper, Collapse, LinearProgress } from '@material-ui/core';
+import { CheckCircle, Error } from '@material-ui/icons';
+import { stylesheet } from 'typestyle';
+
+import {
+  QueryHistoryService,
+  QueryDetailsService,
+} from './service/query_history';
+import { Header } from '../shared/header';
+import LoadingPanel from '../loading_panel';
+import { StripedRows } from '../shared/striped_rows';
+import { formatBytes } from '../details_panel/table_details_panel';
+import { JobsObject, JobIdsObject } from './service/query_history';
+
+const localStyles = stylesheet({
+  body: {
+    height: '100%',
+    overflowY: 'auto',
+    backgroundColor: '#FAFAFA',
+  },
+  query: {
+    flex: 1,
+    minWidth: 0,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  queryBar: {
+    display: 'flex',
+    overflow: 'hidden',
+    padding: '8px 10px 8px 10px',
+    borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)',
+    backgroundColor: 'white',
+  },
+  icon: {
+    marginRight: '12px',
+  },
+  dateGroup: {
+    marginBottom: '12px',
+  },
+  dateHeading: {
+    fontSize: '18px',
+    marginLeft: '10px',
+    padding: '10px 0px 10px 0px',
+  },
+  queryTime: {
+    width: '100px',
+    color: 'gray',
+  },
+  openDetails: {
+    marginBottom: '10px',
+    padding: '12px',
+  },
+});
+
+interface Props {
+  queryHistoryService: QueryHistoryService;
+  currentProject: string;
+}
+
+interface State {
+  hasLoaded: boolean;
+  isLoading: boolean;
+  jobIds: JobIdsObject;
+  jobs: JobsObject;
+  openJob: string;
+}
+
+const QueryDetails = props => {
+  const job = props.details;
+  const rows = [
+    { name: 'Job ID', value: `${job.project}:${job.location}.${job.id}` },
+    { name: 'User', value: job.user },
+    { name: 'Location', value: job.location },
+    { name: 'Creation time', value: job.created },
+    { name: 'Start time', value: job.started },
+    { name: 'End time', value: job.ended },
+    {
+      name: 'Duration',
+      value: job.duration ? `${job.duration.toFixed(2)} sec` : '0.0 sec',
+    },
+    {
+      name: 'Bytes processed',
+      value: job.bytesProcessed
+        ? formatBytes(job.bytesProcessed, 2)
+        : job.from_cache
+        ? '0 B (results cached)'
+        : '0 B',
+    },
+    { name: 'Job priority', value: job.priority },
+    { name: 'Destination table', value: job.destination },
+    { name: 'Use legacy SQL', value: job.useLegacySql ? 'true' : 'false' },
+  ];
+  return <StripedRows rows={rows} />;
+};
+
+const QueryStatus = props => {
+  const failed = props.failed;
+  return (
+    <div
+      style={{
+        padding: '10px 12px 10px 12px',
+        color: 'white',
+        backgroundColor: failed ? '#DA4336' : '#00C752',
+        marginTop: '10px',
+      }}
+    >
+      {failed ? 'Query failed' : 'Query succeeded'}
+    </div>
+  );
+};
+
+class QueryHistoryPanel extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      hasLoaded: false,
+      isLoading: false,
+      jobs: {} as JobsObject,
+      jobIds: {} as JobIdsObject,
+      openJob: null,
+    };
+  }
+
+  componentDidMount() {
+    this.getHistory();
+  }
+
+  handleExpandJob = async jobId => {
+    await this.getQueryDetails(jobId);
+  };
+
+  getQueryDetails = async jobId => {
+    if (!this.state.jobs[jobId].details) {
+      try {
+        const service = new QueryDetailsService();
+        await service.getQueryDetails(jobId).then(queryDetails => {
+          const updatedJobs = { ...this.state.jobs };
+          updatedJobs[jobId]['details'] = queryDetails.job;
+          this.setState({ jobs: updatedJobs });
+        });
+      } catch (err) {
+        console.warn(
+          `Error retrieving query details for query ID ${jobId}`,
+          err
+        );
+      }
+    }
+  };
+
+  private async getHistory() {
+    try {
+      this.setState({ isLoading: true });
+      await this.props.queryHistoryService
+        .getQueryHistory(this.props.currentProject)
+        .then(queryHistory => {
+          const jobIds = queryHistory.jobIds;
+          const jobs = queryHistory.jobs;
+          this.setState({ hasLoaded: true, jobIds: jobIds, jobs: jobs });
+        });
+    } catch (err) {
+      console.warn('Error retrieving query history', err);
+    } finally {
+      this.setState({ isLoading: false });
+    }
+  }
+
+  formatDateString(date) {
+    return `${date.getMonth() + 1}/${date.getDate()}/${date
+      .getFullYear()
+      .toString()
+      .slice(-2)}`;
+  }
+
+  displayDate(date) {
+    const today = new Date();
+    const todayString = this.formatDateString(today);
+    const yesterday = new Date(today.setDate(today.getDate() - 1));
+    const yesterdayString = this.formatDateString(yesterday);
+
+    if (date === todayString) {
+      return 'Today';
+    } else if (date === yesterdayString) {
+      return 'Yesterday';
+    } else {
+      return date;
+    }
+  }
+
+  render() {
+    if (this.state.isLoading) {
+      return (
+        <>
+          <Header text="Query history" /> <LoadingPanel />
+        </>
+      );
+    } else {
+      return (
+        <div style={{ height: '100%' }}>
+          <Header text="Query history" />
+          <div className={localStyles.body}>
+            {Object.keys(this.state.jobIds).map(date => {
+              return (
+                <div
+                  className={localStyles.dateGroup}
+                  key={`query_history_date_${date}`}
+                >
+                  <Paper variant="outlined" square>
+                    <div className={localStyles.dateHeading}>
+                      {this.displayDate(date)}
+                    </div>
+                  </Paper>
+                  {this.state.jobIds[date].map(jobId => {
+                    return (
+                      <div key={jobId}>
+                        <div
+                          onClick={event => {
+                            this.setState({
+                              openJob:
+                                this.state.openJob === jobId ? null : jobId,
+                            });
+                            this.getQueryDetails(jobId);
+                          }}
+                        >
+                          {this.state.openJob === jobId ? (
+                            <QueryStatus
+                              failed={this.state.jobs[jobId].errored}
+                            />
+                          ) : (
+                            <div className={localStyles.queryBar}>
+                              <div className={localStyles.queryTime}>
+                                {this.state.jobs[jobId].time}
+                              </div>
+                              {this.state.jobs[jobId].errored ? (
+                                <Error
+                                  fontSize="inherit"
+                                  htmlColor="rgb(230, 0, 0)"
+                                  className={localStyles.icon}
+                                />
+                              ) : (
+                                <CheckCircle
+                                  fontSize="inherit"
+                                  htmlColor="rgb(0, 199, 82)"
+                                  className={localStyles.icon}
+                                />
+                              )}
+                              <div className={localStyles.query}>
+                                {this.state.jobs[jobId].query}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                        <Collapse in={this.state.openJob === jobId}>
+                          {this.state.jobs[jobId].details ? (
+                            <Paper square className={localStyles.openDetails}>
+                              <QueryDetails
+                                details={this.state.jobs[jobId].details}
+                              />
+                            </Paper>
+                          ) : (
+                            <LinearProgress />
+                          )}
+                        </Collapse>
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      );
+    }
+  }
+}
+
+const mapStateToProps = state => {
+  const currentProject = state.dataTree.data.projectIds[0];
+  return { currentProject };
+};
+
+export default connect(mapStateToProps, {})(QueryHistoryPanel);

--- a/jupyterlab_bigquery/src/components/query_history/query_history_widget.tsx
+++ b/jupyterlab_bigquery/src/components/query_history/query_history_widget.tsx
@@ -1,0 +1,30 @@
+import QueryHistoryPanel from './query_history_panel';
+import * as React from 'react';
+import { ReduxReactWidget } from '../../utils/widgetManager/redux_react_widget';
+import { stylesheet } from 'typestyle';
+import { QueryHistoryService } from './service/query_history';
+
+const localStyles = stylesheet({
+  panel: {
+    backgroundColor: 'white',
+    height: '100%',
+  },
+});
+
+export class QueryHistoryWidget extends ReduxReactWidget {
+  id = 'query-history-tab';
+
+  constructor(private readonly service: QueryHistoryService) {
+    super();
+    this.title.label = 'Query History';
+    this.title.closable = true;
+  }
+
+  renderReact() {
+    return (
+      <div className={localStyles.panel}>
+        <QueryHistoryPanel queryHistoryService={this.service} />
+      </div>
+    );
+  }
+}

--- a/jupyterlab_bigquery/src/components/query_history/service/query_history.ts
+++ b/jupyterlab_bigquery/src/components/query_history/service/query_history.ts
@@ -1,0 +1,115 @@
+import { ServerConnection } from '@jupyterlab/services';
+import { URLExt } from '@jupyterlab/coreutils';
+
+interface QueryHistory {
+  jobs: JobsObject;
+  jobIds: JobIdsObject;
+}
+
+export interface JobIdsObject {
+  [key: string]: string[];
+}
+
+export interface JobsObject {
+  [key: string]: Job;
+}
+
+interface JobDetailsObject {
+  query: string;
+  id: string;
+  user: string;
+  location: string;
+  created: string;
+  started: string;
+  ended: string;
+  duration: number;
+  bytesProcessed: number;
+  priority: string;
+  destination: string;
+  useLegacySql: boolean;
+  state: string;
+  errors: string[];
+  errorResult: string;
+  from_cache: boolean;
+  project: string;
+}
+
+interface Job {
+  query: string;
+  id: string;
+  created: string;
+  time: string;
+  errored: boolean;
+  details?: JobDetailsObject;
+}
+
+interface JobDetails {
+  job: JobDetailsObject;
+}
+
+export class QueryHistoryService {
+  async getQueryHistory(projectId: string): Promise<QueryHistory> {
+    return new Promise((resolve, reject) => {
+      const serverSettings = ServerConnection.makeSettings();
+      const requestUrl = URLExt.join(
+        serverSettings.baseUrl,
+        'bigquery/v1/projectQueryHistory'
+      );
+      const body = { projectId: projectId };
+      const requestInit: RequestInit = {
+        body: JSON.stringify(body),
+        method: 'POST',
+      };
+      ServerConnection.makeRequest(
+        requestUrl,
+        requestInit,
+        serverSettings
+      ).then(response => {
+        response.json().then(data => {
+          if (data.error) {
+            console.error(data.error);
+            reject(data.error);
+            return [];
+          }
+          resolve({
+            jobs: data.jobs,
+            jobIds: data.jobIds,
+          });
+        });
+      });
+    });
+  }
+}
+
+export class QueryDetailsService {
+  async getQueryDetails(jobId: string): Promise<JobDetails> {
+    return new Promise((resolve, reject) => {
+      const serverSettings = ServerConnection.makeSettings();
+      const requestUrl = URLExt.join(
+        serverSettings.baseUrl,
+        'bigquery/v1/getQueryDetails'
+      );
+      const body = { jobId: jobId };
+      const requestInit: RequestInit = {
+        body: JSON.stringify(body),
+        method: 'POST',
+      };
+      ServerConnection.makeRequest(
+        requestUrl,
+        requestInit,
+        serverSettings
+      ).then(response => {
+        response.json().then(data => {
+          if (data.error) {
+            console.error(data.error);
+            reject(data.error);
+            return [];
+          }
+          resolve({
+            job: data,
+          });
+        });
+      });
+    });
+  }
+}

--- a/jupyterlab_bigquery/src/components/shared/striped_rows.tsx
+++ b/jupyterlab_bigquery/src/components/shared/striped_rows.tsx
@@ -17,7 +17,7 @@ export const getStripedStyle = index => {
 
 export const StripedRows = props => {
   return (
-    <div>
+    <div style={{ width: '100%' }}>
       {props.rows.map((row, index) => (
         <div
           key={index}


### PR DESCRIPTION
# Query History feature for BigQuery
The user can click the 'Query History' button at the bottom of the side panel. This opens a new tab containing the query history.

![image](https://user-images.githubusercontent.com/39741440/89673153-e02ccf00-d8b3-11ea-9465-376d4d783b99.png)

## Tab Display
The query history lists query jobs in reverse-chronological order, separated by date, which matches the the WebUI. Each query job includes its creation time, its success status, and its original query text.

![image](https://user-images.githubusercontent.com/39741440/89672619-f5552e00-d8b2-11ea-8108-478ae0c0b124.png)

Clicking on the list item for any query job will expand a details panel with all the information for that query. This detailed display matches the WebUI.

![image](https://user-images.githubusercontent.com/39741440/89672638-fe45ff80-d8b2-11ea-8bf0-79b6d78abec3.png)

Co-authored-by: Heather Wing, Cynthia Jia