### PR TITLE
[Optimizer] fix dialogs not being cleared properly

### DIFF
--- a/jupyterlab_caip_optimizer/src/components/suggest_trials/add_measurement_dialog.tsx
+++ b/jupyterlab_caip_optimizer/src/components/suggest_trials/add_measurement_dialog.tsx
@@ -64,6 +64,9 @@ export const AddMeasurementDialog: React.FC<Props> = ({
   const handleClose = () => {
     if (!loading) {
       setMetrics(clearMetrics(metrics));
+      setFinalMeasurement(true);
+      setInfeasible(false);
+      setInfeasibleReason('');
       close();
     }
   };
@@ -102,8 +105,7 @@ export const AddMeasurementDialog: React.FC<Props> = ({
     }
 
     setLoading(false);
-    setMetrics(clearMetrics(metrics));
-    close();
+    handleClose();
   };
 
   return (

--- a/jupyterlab_caip_optimizer/src/components/suggest_trials/create_trial.tsx
+++ b/jupyterlab_caip_optimizer/src/components/suggest_trials/create_trial.tsx
@@ -159,21 +159,23 @@ export const CreateTrial: React.FC<Props> = ({
   onClose,
 }) => {
   const dispatch = useDispatch();
+  // Creates parameter default values of '' and setups input error handling
+  // using the custom hook
+  const [map, setInput, clearInputs] = useErrorStateMap(
+    parameterSpecToInputsValues(studyConfig.parameters),
+    parameterSpecToValidateInput(studyConfig.parameters)
+  );
   const [metrics, setMetrics] = React.useState<MetricsInputs>(() =>
     metricSpecsToMetrics(studyConfig.metrics)
   );
   const [requested, setRequested] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
-  // Creates parameter default values of '' and setups input error handling
-  // using the custom hook
-  const [map, setInput] = useErrorStateMap(
-    parameterSpecToInputsValues(studyConfig.parameters),
-    parameterSpecToValidateInput(studyConfig.parameters)
-  );
 
   const handleClose = () => {
     if (!loading) {
+      clearInputs();
       setMetrics(clearMetrics(metrics));
+      setRequested(false);
       onClose();
     }
   };
@@ -211,7 +213,6 @@ export const CreateTrial: React.FC<Props> = ({
       );
     }
     setLoading(false);
-    setMetrics(clearMetrics(metrics));
     onClose();
   };
 

--- a/jupyterlab_caip_optimizer/src/utils/use_error_state_map.ts
+++ b/jupyterlab_caip_optimizer/src/utils/use_error_state_map.ts
@@ -7,7 +7,8 @@ export type ErrorStateMap<V> = {
 
 export type ErrorStateArrayReturn<O, V> = [
   ErrorStateMap<V>,
-  (name: keyof O, value: V) => void
+  (name: keyof O, value: V) => void,
+  () => void
 ];
 
 export type ErrorCheckFunction<V> = (
@@ -74,5 +75,9 @@ export function useErrorStateMap<O extends object, V = O[keyof O]>(
     }
   };
 
-  return [map, setValue];
+  const clear = () => {
+    setMap(getDefaultState(defaultValues));
+  };
+
+  return [map, setValue, clear];
 }


### PR DESCRIPTION
# Description

Fixes add measurement and create custom trial dialogs not clearing input data after closing the dialog.

# Old

https://screencast.googleplex.com/cast/NjA0ODczMTQ4NzAxMDgxNnxjNmZjZDQwOS01NQ

# New

https://screencast.googleplex.com/cast/NDkyMTMzNDcxNjk1NjY3MnxlMmZjNzFlZS1mOA