### PR TITLE
[HardwareConfiguration] Fixing UI bugs

### DIFF
--- a/jupyterlab_gcedetails/src/components/action_bar.tsx
+++ b/jupyterlab_gcedetails/src/components/action_bar.tsx
@@ -1,0 +1,54 @@
+import * as csstips from 'csstips';
+import * as React from 'react';
+import { stylesheet, classes } from 'typestyle';
+import { css, COLORS } from 'gcp_jupyterlab_shared';
+
+interface Props {
+  primaryLabel: string;
+  secondaryLabel?: string;
+  onPrimaryClick: () => void;
+  onSecondaryClick?: () => void;
+}
+
+const STYLES = stylesheet({
+  actionBar: {
+    padding: '16px',
+    marginTop: '5px',
+    display: 'block',
+    $nest: {
+      '&>*': {
+        marginLeft: '16px',
+      },
+    },
+    ...csstips.horizontal,
+    ...csstips.endJustified,
+  },
+  primaryButton: {
+    backgroundColor: COLORS.blue,
+    color: COLORS.white,
+  },
+});
+
+/** Funtional Component for defining an action bar with buttons. */
+export function ActionBar(props: Props) {
+  return (
+    <div className={STYLES.actionBar}>
+      {props.secondaryLabel && (
+        <button
+          type="button"
+          className={css.button}
+          onClick={props.onSecondaryClick}
+        >
+          {props.secondaryLabel}
+        </button>
+      )}
+      <button
+        type="button"
+        className={classes(css.button, STYLES.primaryButton)}
+        onClick={props.onPrimaryClick}
+      >
+        {props.primaryLabel}
+      </button>
+    </div>
+  );
+}

--- a/jupyterlab_gcedetails/src/components/confirmation_page.tsx
+++ b/jupyterlab_gcedetails/src/components/confirmation_page.tsx
@@ -17,15 +17,11 @@
 import * as csstips from 'csstips';
 import * as React from 'react';
 
-import {
-  BASE_FONT,
-  ActionBar,
-  SubmitButton,
-  Message,
-} from 'gcp_jupyterlab_shared';
+import { BASE_FONT, Message } from 'gcp_jupyterlab_shared';
 import { stylesheet, classes } from 'typestyle';
 import { HardwareConfiguration, ACCELERATOR_TYPES } from '../data';
 import { HardwareConfigurationDescription } from './hardware_scaling_form';
+import { ActionBar } from './action_bar';
 
 interface Props {
   formData: HardwareConfiguration;
@@ -101,13 +97,12 @@ export function ConfirmationPage(props: Props) {
       <div className={STYLES.infoMessage}>
         <Message asError={false} asActivity={false} text={INFO_MESSAGE} />
       </div>
-      <ActionBar closeLabel="Cancel" onClick={onDialogClose}>
-        <SubmitButton
-          actionPending={false}
-          onClick={() => onSubmit()}
-          text="Submit"
-        />
-      </ActionBar>
+      <ActionBar
+        primaryLabel="Submit"
+        onPrimaryClick={() => onSubmit()}
+        secondaryLabel="Cancel"
+        onSecondaryClick={onDialogClose}
+      />
     </div>
   );
 }

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
@@ -22,8 +22,6 @@ import {
   CheckboxInput,
   LearnMoreLink,
   BASE_FONT,
-  ActionBar,
-  SubmitButton,
   Option,
 } from 'gcp_jupyterlab_shared';
 import { stylesheet, classes } from 'typestyle';
@@ -42,6 +40,7 @@ import {
   Details,
   detailsToHardwareConfiguration,
 } from '../data';
+import { ActionBar } from './action_bar';
 
 interface Props {
   onSubmit: (configuration: HardwareConfiguration) => void;
@@ -59,7 +58,7 @@ export const STYLES = stylesheet({
     marginRight: '10px',
   },
   checkboxContainer: {
-    paddingBottom: '8px',
+    padding: '8px 0px 8px 0px',
   },
   title: {
     ...BASE_FONT,
@@ -272,13 +271,12 @@ export class HardwareScalingForm extends React.Component<Props, State> {
             )}
           </form>
         </div>
-        <ActionBar closeLabel="Cancel" onClick={onDialogClose}>
-          <SubmitButton
-            actionPending={false}
-            onClick={() => this.submitForm()}
-            text="Next"
-          />
-        </ActionBar>
+        <ActionBar
+          primaryLabel="Next"
+          onPrimaryClick={() => this.submitForm()}
+          secondaryLabel="Cancel"
+          onSecondaryClick={onDialogClose}
+        />
       </div>
     );
   }

--- a/jupyterlab_gcedetails/src/components/machine_type_select.tsx
+++ b/jupyterlab_gcedetails/src/components/machine_type_select.tsx
@@ -27,7 +27,7 @@ import TextField from '@material-ui/core/TextField';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
-import { Option, TEXT_STYLE, TEXT_LABEL_STYLE } from '../data';
+import { Option, TEXT_STYLE } from '../data';
 
 const STYLES = stylesheet({
   itemGroup: {
@@ -45,7 +45,7 @@ const STYLES = stylesheet({
     paddingBottom: '8px',
   },
   input: {
-    marginTop: '4px',
+    marginTop: '2px',
   },
 });
 
@@ -271,11 +271,8 @@ export class NestedSelect extends React.Component<
 
     return (
       <div className={STYLES.nestedSelect}>
+        {label && <label>{label}</label>}
         <TextField
-          InputLabelProps={{
-            style: TEXT_LABEL_STYLE,
-          }}
-          label={label}
           className={STYLES.input}
           value={this.displayValue(value)}
           margin="dense"

--- a/jupyterlab_gcedetails/src/components/select_input.tsx
+++ b/jupyterlab_gcedetails/src/components/select_input.tsx
@@ -19,7 +19,7 @@ import { stylesheet } from 'typestyle';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import TextField from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
-import { Option, TEXT_STYLE, TEXT_LABEL_STYLE } from '../data';
+import { Option, TEXT_STYLE } from '../data';
 
 interface Props {
   label?: string;
@@ -32,7 +32,7 @@ interface Props {
 export const STYLES = stylesheet({
   select: {
     display: 'block',
-    marginTop: '4px',
+    marginTop: '2px',
   },
   icon: {
     right: '14px',
@@ -49,11 +49,8 @@ export function SelectInput(props: Props) {
 
   return (
     <div>
+      {label && <label>{label}</label>}
       <TextField
-        InputLabelProps={{
-          style: TEXT_LABEL_STYLE,
-        }}
-        label={label}
         className={STYLES.select}
         select
         value={value}

--- a/jupyterlab_gcedetails/src/data.ts
+++ b/jupyterlab_gcedetails/src/data.ts
@@ -119,7 +119,7 @@ function nvidiaNameToEnum(name: string): string {
     accelerator.text.endsWith(name)
   );
 
-  return accelerator ? NO_ACCELERATOR : (accelerator.value as string);
+  return accelerator ? (accelerator.value as string) : NO_ACCELERATOR;
 }
 
 /**
@@ -423,11 +423,4 @@ export const STYLES = stylesheet({
 export const TEXT_STYLE = {
   fontFamily: BASE_FONT.fontFamily as string,
   fontSize: BASE_FONT.fontSize as number,
-};
-
-export const TEXT_LABEL_STYLE = {
-  ...TEXT_STYLE,
-  fontSize: '15px',
-  paddingRight: '2px',
-  backgroundColor: '#FFFFFF',
 };


### PR DESCRIPTION
- An update to the shared/action_bar.tsx file caused the buttons to overlap with the input on the hardware scaling form. Resolved this by creating an action_bar component specifically for gce_details (we were probably going to do this anyways because we need to add some more gce_details specific functionality to the action_bar):
![image](https://user-images.githubusercontent.com/28398459/89847420-f48df780-db51-11ea-8410-e668e41e65a6.png)


- Testing the extension on a real Notebook Instance showed that the input labels incorporated from material-ui on the hardware scaling form were rendering strangely. Switched to using native labels for now - will look more into this if we decide we want to keep the material-ui labels:
![image](https://user-images.githubusercontent.com/28398459/89847726-a9c0af80-db52-11ea-91a8-ef9adf111b4b.png)


Hardware scaling form with changes made in this commit:
![Screenshot 2020-08-10 at 9 04 07 PM](https://user-images.githubusercontent.com/28398459/89847785-ceb52280-db52-11ea-8d98-9a24c7633333.png)
