### PR TITLE
[BigQuery] Side panel UI patches

### DIFF
--- a/jupyterlab_bigquery/jupyterlab_bigquery/list_items_handler/service.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/list_items_handler/service.py
@@ -69,6 +69,7 @@ class BigQueryService:
         'name': table.table_id,
         'datasetId': dataset_id,
         'type': table.table_type,
+        'partitioned': True if table.partitioning_type else False,
       }
       table_ids.append(table_full_id)
 

--- a/jupyterlab_bigquery/jupyterlab_bigquery/tests/list_items_service_test.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/tests/list_items_service_test.py
@@ -101,6 +101,7 @@ class TestListTree(unittest.TestCase):
           'name': 'dummy_table1',
           'datasetId': 'dummy_dataset1',
           'type': None,
+          'partitioned': False,
         }
       },
       'tableIds': ['dummy_project1.dummy_dataset1.dummy_table1']
@@ -174,19 +175,19 @@ class TestListTree(unittest.TestCase):
         'type': 'table',
         'parent': 'dummy_dataset',
         'name': 'dummy_table',
-        'id': 'dummy_dataset.dummy_table',
+        'id': 'dummy_project.dummy_dataset.dummy_table',
       },
       {
         'type': 'view',
         'parent': 'dummy_dataset',
         'name': 'dummy_view',
-        'id': 'dummy_dataset.dummy_view',
+        'id': 'dummy_project.dummy_dataset.dummy_view',
       },
       {
         'type': 'model',
         'parent': 'dummy_dataset',
         'name': 'dummy_model',
-        'id': 'dummy_dataset.dummy_model',
+        'id': 'dummy_project.dummy_dataset.dummy_model',
       },
     ]}
 

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
@@ -82,6 +82,10 @@ const localStyles = stylesheet({
     display: 'flex',
     justifyContent: 'space-between',
   },
+  headerTitle: {
+    display: 'flex',
+    alignItems: 'center',
+  },
   resources: {
     borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)',
     padding: '8px 12px',
@@ -100,6 +104,7 @@ const localStyles = stylesheet({
     display: 'flex',
     flexDirection: 'row',
     marginBottom: '8px',
+    alignItems: 'center',
   },
   search: {
     marginBottom: '8px',
@@ -288,6 +293,7 @@ class ListItemsPanel extends React.Component<Props, State> {
           this.props.addProject(project);
         } else {
           console.log('This project does not exist');
+          this.props.openSnackbar(`Project ${newProjectId} does not exist.`);
         }
       });
     } catch (err) {
@@ -363,7 +369,7 @@ class ListItemsPanel extends React.Component<Props, State> {
           <CustomSnackbar open={snackbar.open} message={snackbar.message} />
         </Portal>
         <header className={localStyles.header}>
-          <div>BigQuery Extension</div>
+          <div className={localStyles.headerTitle}>BigQuery Extension</div>
           <div className={localStyles.buttonContainer}>
             <Tooltip title="Open SQL editor">
               <Button
@@ -401,17 +407,15 @@ class ListItemsPanel extends React.Component<Props, State> {
                   <RefreshIcon fontSize="small" />
                 </IconButton>
               </Tooltip>
-              <Tooltip title="Pin project">
-                <Button
+              <Tooltip title="Add project">
+                <IconButton
                   size="small"
-                  variant="outlined"
-                  style={{ minWidth: 0 }}
-                  className={localStyles.pinProjectsButton}
+                  aria-label="close"
+                  color="inherit"
                   onClick={this.handleOpenPinProject}
-                  startIcon={<AddIcon />}
                 >
-                  <div className={localStyles.buttonLabel}>Pin project</div>
-                </Button>
+                  <AddIcon fontSize="small" />
+                </IconButton>
               </Tooltip>
             </div>
           </div>

--- a/jupyterlab_bigquery/src/components/list_items_panel/service/list_items.ts
+++ b/jupyterlab_bigquery/src/components/list_items_panel/service/list_items.ts
@@ -33,6 +33,7 @@ export interface Table {
   type: string;
   datasetId: string;
   parent: string;
+  partitioned: boolean;
 }
 
 export interface Model {

--- a/jupyterlab_bigquery/src/reducers/dataTreeSlice.ts
+++ b/jupyterlab_bigquery/src/reducers/dataTreeSlice.ts
@@ -44,6 +44,16 @@ const dataTreeSlice = createSlice({
         state.data.projectIds.push(projectId);
       }
     },
+    removeProject(state, action: PayloadAction<Project>) {
+      const projectResult = action.payload;
+      const projectId = projectResult.id;
+      if (state.data.projects[projectId]) {
+        delete state.data.projects[projectId];
+        state.data.projectIds = state.data.projectIds.filter(
+          item => item !== projectId
+        );
+      }
+    },
     updateDataset(state, action: PayloadAction<Dataset>) {
       const datasetResult = action.payload;
       const datasetId = datasetResult.id;
@@ -61,6 +71,7 @@ export const {
   updateProject,
   updateDataset,
   addProject,
+  removeProject,
 } = dataTreeSlice.actions;
 
 export default dataTreeSlice.reducer;

--- a/jupyterlab_bigquery/style/images/table_partitioned_18px.svg
+++ b/jupyterlab_bigquery/style/images/table_partitioned_18px.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+    <title>18/ic-table-partitioned</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="18/ic-table-partitioned" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <polygon id="Container" points="0 0 18 0 18 18 0 18"></polygon>
+        <path d="M2,4.00585866 C2,2.89805351 2.89706013,2 4.00585866,2 L13.9941413,2 C15.1019465,2 16,2.89706013 16,4.00585866 L16,13.9941413 C16,15.1019465 15.1029399,16 13.9941413,16 L4.00585866,16 C2.89805351,16 2,15.1029399 2,13.9941413 L2,4.00585866 Z M16,8 L16,10 L2,10 L2,8 L16,8 Z M4,4 L14,4 L14,6 L4,6 L4,4 Z M4,12 L6,12 L6,14 L4,14 L4,12 Z M12,12 L14,12 L14,14 L12,14 L12,12 Z M8,12 L10,12 L10,14 L8,14 L8,12 Z" id="Shape" fill="#000000"></path>
+    </g>
+</svg>

--- a/jupyterlab_bigquery/style/index.css
+++ b/jupyterlab_bigquery/style/index.css
@@ -10,6 +10,10 @@
   background-image: url('./images/table_20px.svg');
   background-size: contain;
 }
+.jp-PartitionedTableIcon {
+  background-image: url('./images/table_partitioned_18px.svg');
+  background-size: contain;
+}
 .jp-ViewIcon {
   background-image: url('./images/table_view_24px.svg');
   background-size: contain;


### PR DESCRIPTION
# Side panel UI patches
Updates include:
- Add icons for partitioned tables
- Change the pin project button and the header display
- Fix the snackbar not displaying
- Fix unit test for searching
- Add 'Unpin project' option to project context menu

## Partitioned tables
New icon for partitioned tables:

![image](https://user-images.githubusercontent.com/39741440/89930654-15e5f680-dbd9-11ea-8e3a-db50f5000c34.png)

## Pin projects button and header changes
Minor changes to the header, including changing pin projects button to just an icon (confirmed with Huaiwei):

![image](https://user-images.githubusercontent.com/39741440/89930730-331ac500-dbd9-11ea-9fdb-15e34d542514.png)

## Fix snackbar
Fix problems with snackbar displaying incorrectly when pinning projects.

![image](https://user-images.githubusercontent.com/39741440/89930931-7f660500-dbd9-11ea-95fe-fa43fd6e6e9e.png)

## Searching tests fixed
Fixed issues in unit tests for searching. All backend tests now pass.

## Unpin project
New context menu option for projects:

![image](https://user-images.githubusercontent.com/39741440/89931029-a4f30e80-dbd9-11ea-8a58-4477cfb7abed.png)
