### PR TITLE
[BigQuery] Query history improvements

### DIFF
--- a/jupyterlab_bigquery/jupyterlab_bigquery/query_history_handler/query_history_handler.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/query_history_handler/query_history_handler.py
@@ -37,7 +37,7 @@ def format_value(value):
     else:
       return value
   elif isinstance(value, datetime.datetime):
-    return json.dumps(value.strftime('%b %e, %G, %l:%M:%S %p'))[1:-1]
+    return value.isoformat().__str__()
   else:
     return value.__str__()
 
@@ -52,22 +52,17 @@ def list_jobs(client, project):
   jobs = list(client.list_jobs(project))
 
   jobs_list = {}
-  job_ids = {}
+  job_ids = []
   for job in jobs:
     if job.job_type != 'query':
       continue
     jobs_list[job.job_id] = {
         'query': job.query,
         'id': job.job_id,
-        'created': format_value(job.created),
-        'time': json.dumps(job.created.strftime('%l:%M %p'))[1:-1],
+        'created': job.created.isoformat().__str__(),
         'errored': True if job.errors else False
     }
-    curr_date = json.dumps(job.created.strftime('%-m/%-d/%y'))[1:-1]
-    if curr_date in job_ids:
-      job_ids[curr_date].append(job.job_id)
-    else:
-      job_ids[curr_date] = [job.job_id]
+    job_ids.append(job.job_id)
 
   return {'jobs': jobs_list, 'jobIds': job_ids}
 

--- a/jupyterlab_bigquery/jupyterlab_bigquery/tests/query_history_handler_test.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/tests/query_history_handler_test.py
@@ -49,14 +49,11 @@ class TestQueryHistory(unittest.TestCase):
             'dummy_job': {
                 'query': 'SELECT * FROM *',
                 'id': 'dummy_job',
-                'created': 'Jul 14, 2020,  1:23:45 PM',
-                'time': ' 1:23 PM',
+                'created': '2020-07-14T13:23:45.000067',
                 'errored': True,
             }
         },
-        'jobIds': {
-            '7/14/20': ['dummy_job']
-        },
+        'jobIds': ['dummy_job'],
     }
 
     got = list_jobs(mock_client, 'dummy_dataset1')
@@ -90,11 +87,11 @@ class TestQueryHistory(unittest.TestCase):
                                             14,
                                             13,
                                             23,
-                                            45,
+                                            46,
                                             67,
                                             tzinfo=None),
                     estimated_bytes_processed=1,
-                    priority=1,
+                    priority='INTERACTIVE',
                     destination=mock_table_ref,
                     use_legacy_sql=False,
                     state='Done',
@@ -112,12 +109,12 @@ class TestQueryHistory(unittest.TestCase):
         'id': 'dummy_job',
         'user': 'dummy_email',
         'location': 'US',
-        'created': 'Jul 14, 2020,  1:23:45 PM',
-        'started': 'Jul 14, 2020,  1:23:45 PM',
-        'ended': 'Jul 14, 2020,  1:23:45 PM',
-        'duration': 0.0,
+        'created': '2020-07-14T13:23:45.000067',
+        'started': '2020-07-14T13:23:45.000067',
+        'ended': '2020-07-14T13:23:46.000067',
+        'duration': 1,
         'bytesProcessed': 1,
-        'priority': 1,
+        'priority': 'INTERACTIVE',
         'destination': 'dummy_table',
         'useLegacySql': False,
         'state': 'Done',
@@ -128,6 +125,98 @@ class TestQueryHistory(unittest.TestCase):
     }
 
     got = get_job_details(mock_client, 'dummy_job')
+    self.assertEqual(wanted, got)
+
+  def testGetJobDetailsErrors(self):
+    mock_table = Mock(id='dummy_table')
+    mock_table_ref = Mock(id='dummy_table')
+
+    mock_job = Mock(
+        query='SELECT * FROMs `cxjia-sandbox.babynames.names_1987` LIMITs 200',
+        user_email='dummy_email',
+        location='US',
+        created=datetime.datetime(2020, 7, 14, 13, 23, 45, 67, tzinfo=None),
+        started=datetime.datetime(2020, 7, 14, 13, 23, 45, 67, tzinfo=None),
+        ended=datetime.datetime(2020, 7, 14, 13, 23, 45, 67, tzinfo=None),
+        estimated_bytes_processed=0.0,
+        priority='INTERACTIVE',
+        destination=mock_table_ref,
+        use_legacy_sql=False,
+        state='Done',
+        errors=[{
+            'reason':
+                'invalidQuery',
+            'location':
+                'query',
+            'message':
+                'Syntax error: Expected end of input but got identifier "FROMs" at [1:10]'
+        }],
+        error_result={
+            'reason':
+                'invalidQuery',
+            'location':
+                'query',
+            'message':
+                'Syntax error: Expected end of input but got identifier "FROMs" at [1:10]'
+        },
+        cache_hit=None,
+        project=None)
+
+    mock_client = Mock()
+    mock_client.get_table = MagicMock(return_value=mock_table)
+    mock_client.get_job = MagicMock(return_value=mock_job)
+
+    wanted = {
+        'query':
+            'SELECT * FROMs `cxjia-sandbox.babynames.names_1987` LIMITs 200',
+        'id':
+            'dummy_job',
+        'user':
+            'dummy_email',
+        'location':
+            'US',
+        'created':
+            '2020-07-14T13:23:45.000067',
+        'started':
+            '2020-07-14T13:23:45.000067',
+        'ended':
+            '2020-07-14T13:23:45.000067',
+        'duration':
+            0.0,
+        'bytesProcessed':
+            0.0,
+        'priority':
+            'INTERACTIVE',
+        'destination':
+            'dummy_table',
+        'useLegacySql':
+            False,
+        'state':
+            'Done',
+        'errors': [{
+            'reason':
+                'invalidQuery',
+            'location':
+                'query',
+            'message':
+                'Syntax error: Expected end of input but got identifier "FROMs" at [1:10]'
+        }],
+        'errorResult': {
+            'reason':
+                'invalidQuery',
+            'location':
+                'query',
+            'message':
+                'Syntax error: Expected end of input but got identifier "FROMs" at [1:10]'
+        },
+        'from_cache':
+            None,
+        'project':
+            None,
+    }
+
+    got = get_job_details(mock_client, 'dummy_job')
+    self.maxDiff = None
     self.assertEqual(wanted, got)
 
 

--- a/jupyterlab_bigquery/package-lock.json
+++ b/jupyterlab_bigquery/package-lock.json
@@ -298,6 +298,22 @@
 				"react": "~16.8.4"
 			}
 		},
+		"@jupyterlab/launcher": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@jupyterlab/launcher/-/launcher-1.2.8.tgz",
+			"integrity": "sha512-n2GDG0CcRz1KIt5MLpB9QKOmM3Mq+1OWm7bzsdRFAoEDM/lMRJYthIdDWHjjKQ3ehB5Y/beAUqHEAjSmkvVacQ==",
+			"requires": {
+				"@jupyterlab/apputils": "^1.2.8",
+				"@jupyterlab/ui-components": "^1.2.1",
+				"@phosphor/algorithm": "^1.2.0",
+				"@phosphor/commands": "^1.7.0",
+				"@phosphor/coreutils": "^1.3.1",
+				"@phosphor/disposable": "^1.3.0",
+				"@phosphor/properties": "^1.1.3",
+				"@phosphor/widgets": "^1.9.0",
+				"react": "~16.8.4"
+			}
+		},
 		"@jupyterlab/notebook": {
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/@jupyterlab/notebook/-/notebook-1.2.9.tgz",
@@ -479,6 +495,116 @@
 				"@phosphor/widgets": "^1.9.0",
 				"react": "~16.8.4",
 				"typestyle": "^2.0.1"
+			}
+		},
+		"@lumino/widgets": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.13.4.tgz",
+			"integrity": "sha512-1Dv9oLSnte4G7Ndc7DAssSURPavVW/vQK7q1WGj9v/4Z7caeyw+OraimXdgOyxGDjnarKEpEFsWgoEs2DMxdrQ==",
+			"requires": {
+				"@lumino/algorithm": "^1.3.3",
+				"@lumino/commands": "^1.11.3",
+				"@lumino/coreutils": "^1.5.3",
+				"@lumino/disposable": "^1.4.3",
+				"@lumino/domutils": "^1.2.3",
+				"@lumino/dragdrop": "^1.6.4",
+				"@lumino/keyboard": "^1.2.3",
+				"@lumino/messaging": "^1.4.3",
+				"@lumino/properties": "^1.2.3",
+				"@lumino/signaling": "^1.4.3",
+				"@lumino/virtualdom": "^1.7.3"
+			},
+			"dependencies": {
+				"@lumino/algorithm": {
+					"version": "1.3.3",
+					"resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.3.3.tgz",
+					"integrity": "sha512-I2BkssbOSLq3rDjgAC3fzf/zAIwkRUnAh60MO0lYcaFdSGyI15w4K3gwZHGIO0p9cKEiNHLXKEODGmOjMLOQ3g=="
+				},
+				"@lumino/collections": {
+					"version": "1.3.3",
+					"resolved": "https://registry.npmjs.org/@lumino/collections/-/collections-1.3.3.tgz",
+					"integrity": "sha512-vN3GSV5INkgM6tMLd+WqTgaPnQNTY7L/aFUtTOC8TJQm+vg1eSmR4fNXsoGHM3uA85ctSJThvdZr5triu1Iajg==",
+					"requires": {
+						"@lumino/algorithm": "^1.3.3"
+					}
+				},
+				"@lumino/commands": {
+					"version": "1.11.3",
+					"resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.11.3.tgz",
+					"integrity": "sha512-0JencVUzJWEaXVDngpLhgOWza6Yql5tq2W2Qsi9U3exEDE3CqXdjehI/Uy4Cj2+aAfZju8iPvyZVlLq2psyKLw==",
+					"requires": {
+						"@lumino/algorithm": "^1.3.3",
+						"@lumino/coreutils": "^1.5.3",
+						"@lumino/disposable": "^1.4.3",
+						"@lumino/domutils": "^1.2.3",
+						"@lumino/keyboard": "^1.2.3",
+						"@lumino/signaling": "^1.4.3",
+						"@lumino/virtualdom": "^1.7.3"
+					}
+				},
+				"@lumino/coreutils": {
+					"version": "1.5.3",
+					"resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.5.3.tgz",
+					"integrity": "sha512-G72jJ6sgOwAUuilz+cri7LpHIJxllK+qz+YZUC3fyyWHK7oRlZemcc43jZAVE+tagTdMxKYSQWNIVzM5lI8sWw=="
+				},
+				"@lumino/disposable": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.4.3.tgz",
+					"integrity": "sha512-zKQ9N2AEGcYpG6PJkeMWQXvoXU9w1ocji78z+fboM/SmSgtOIVGeQt3fZeldymf0XrlOPpNXs1ZFg54yWUMnXA==",
+					"requires": {
+						"@lumino/algorithm": "^1.3.3",
+						"@lumino/signaling": "^1.4.3"
+					}
+				},
+				"@lumino/domutils": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-1.2.3.tgz",
+					"integrity": "sha512-SEi8WZSy+DWMkL5CfAY78MHbi3x83AVmRFxjs9+A6qsFPde+Hr1I4DNtLsSDmfAWsobHHgBnjyNp2ZkQEq0IEA=="
+				},
+				"@lumino/dragdrop": {
+					"version": "1.6.4",
+					"resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.6.4.tgz",
+					"integrity": "sha512-t+tQazxg/fyyC7T1wm7mnSfUDNPvAbKHRDWaIbBRVjf6M+B5N8eFwwqMZ63nKdzZPbwX6DJq+D2DNlqIB7gOjg==",
+					"requires": {
+						"@lumino/coreutils": "^1.5.3",
+						"@lumino/disposable": "^1.4.3"
+					}
+				},
+				"@lumino/keyboard": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.2.3.tgz",
+					"integrity": "sha512-ibS0sz0VABeuJXx2JVSz36sUBMUOcQNCNPybVhwzN/GkJFs0dnDKluMu+3Px0tkB2y33bGPZU/RLZY1Xj/faEA=="
+				},
+				"@lumino/messaging": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/@lumino/messaging/-/messaging-1.4.3.tgz",
+					"integrity": "sha512-wa2Pj2KOuLNLS2n0wVBzUVFGbvjL1FLbuCOAUEYfN6xXVleqqtGGzd08uTF7ebu01KCO3VQ38+dkvoaM/C2qPw==",
+					"requires": {
+						"@lumino/algorithm": "^1.3.3",
+						"@lumino/collections": "^1.3.3"
+					}
+				},
+				"@lumino/properties": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-1.2.3.tgz",
+					"integrity": "sha512-dbS9V/L+RpQoRjxHMAGh1JYoXaLA6F7xkVbg/vmYXqdXZ7DguO5C3Qteu9tNp7Z7Q31TqFWUCrniTI9UJiJCoQ=="
+				},
+				"@lumino/signaling": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.4.3.tgz",
+					"integrity": "sha512-6clc8SMcH0tyKXIX31xw6sxjxJl5hj4YRd1DTHTS62cegQ0FkO8JjJeuv+Nc1pgTg6nEAf65aSOHpUdsFHDAvQ==",
+					"requires": {
+						"@lumino/algorithm": "^1.3.3"
+					}
+				},
+				"@lumino/virtualdom": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.7.3.tgz",
+					"integrity": "sha512-YgQyyo5F7nMfcp5wbpJQyBsztFqAQPO1++sbPCJiF8Mt0Zo5+hN0jWG2tw7IymHdXDNypgnrCiiHQZMUXuzCiA==",
+					"requires": {
+						"@lumino/algorithm": "^1.3.3"
+					}
+				}
 			}
 		},
 		"@material-ui/core": {

--- a/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
@@ -11,9 +11,8 @@ import {
   withStyles,
 } from '@material-ui/core';
 import { stylesheet } from 'typestyle';
-import Editor from '@monaco-editor/react';
-import { monaco } from '@monaco-editor/react';
 
+import ReadOnlyEditor from '../shared/read_only_editor';
 import { SchemaField } from './service/list_table_details';
 import { ModelSchema } from './service/list_model_details';
 import { StripedRows } from '../shared/striped_rows';
@@ -112,39 +111,6 @@ const getTitle = type => {
 export const DetailsPanel: React.SFC<Props> = props => {
   const { details, rows, detailsType } = props;
 
-  function handleEditorDidMount(_, editor) {
-    const editorElement = editor.getDomNode();
-    if (!editorElement) {
-      return;
-    }
-
-    monaco
-      .init()
-      .then(monaco => {
-        const lineHeight = editor.getOption(
-          monaco.editor.EditorOption.lineHeight
-        );
-        const lineCount = editor._modelData.viewModel.getLineCount();
-        const height = lineCount * lineHeight;
-        editorElement.style.height = `${height}px`;
-        editor.layout();
-
-        monaco.editor.defineTheme('viewQueryTheme', {
-          base: 'vs',
-          inherit: true,
-          rules: [],
-          colors: { 'editorCursor.foreground': '#FFFFFF' },
-        });
-        monaco.editor.setTheme('viewQueryTheme');
-      })
-      .catch(error =>
-        console.error(
-          'An error occurred during initialization of Monaco: ',
-          error
-        )
-      );
-  }
-
   return (
     <div className={localStyles.panel}>
       <div className={localStyles.detailsBody}>
@@ -219,28 +185,7 @@ export const DetailsPanel: React.SFC<Props> = props => {
             <div className={localStyles.title} style={{ marginTop: '32px' }}>
               Query
             </div>
-            <Editor
-              width="100%"
-              theme={'light'}
-              language={'sql'}
-              value={details.query}
-              options={{
-                readOnly: true,
-                minimap: { enabled: false },
-                cursorStyle: 'line-thin',
-                cursorWidth: 0,
-                renderLineHighlight: 'none',
-                overviewRulerLanes: 0,
-                overviewRulerBorder: false,
-                hideCursorInOverviewRuler: true,
-                glyphMargin: true,
-                matchBrackets: 'never',
-                occurrencesHighlight: false,
-                folding: false,
-                scrollBeyondLastLine: false,
-              }}
-              editorDidMount={handleEditorDidMount}
-            />
+            <ReadOnlyEditor query={details.query} />
           </div>
         )}
 

--- a/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
+++ b/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Paper, Collapse, LinearProgress } from '@material-ui/core';
+import { Paper, Collapse, LinearProgress, Icon } from '@material-ui/core';
 import { CheckCircle, Error } from '@material-ui/icons';
 import { stylesheet } from 'typestyle';
+import { DateTime } from 'luxon';
 
 import {
   QueryHistoryService,
@@ -12,7 +13,12 @@ import { Header } from '../shared/header';
 import LoadingPanel from '../loading_panel';
 import { StripedRows } from '../shared/striped_rows';
 import { formatBytes } from '../details_panel/table_details_panel';
-import { JobsObject, JobIdsObject } from './service/query_history';
+import ReadOnlyEditor from '../shared/read_only_editor';
+import { JobsObject, Job } from './service/query_history';
+import { QueryEditorTabWidget } from '../query_editor/query_editor_tab/query_editor_tab_widget';
+import { WidgetManager } from '../../utils/widgetManager/widget_manager';
+import { generateQueryId } from '../../reducers/queryEditorTabSlice';
+import { formatTime, formatDate } from '../../utils/formatters';
 
 const localStyles = stylesheet({
   body: {
@@ -30,9 +36,31 @@ const localStyles = stylesheet({
   queryBar: {
     display: 'flex',
     overflow: 'hidden',
-    padding: '8px 10px 8px 10px',
+    padding: '0px 10px 0px 10px',
     borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)',
     backgroundColor: 'white',
+    alignItems: 'center',
+    '&:hover': {
+      cursor: 'pointer',
+    },
+  },
+  queryStatusBarFailed: {
+    padding: '10px 12px 10px 12px',
+    color: 'white',
+    backgroundColor: '#DA4336',
+    marginTop: '10px',
+    '&:hover': {
+      cursor: 'pointer',
+    },
+  },
+  queryStatusBarSucceeded: {
+    padding: '10px 12px 10px 12px',
+    color: 'white',
+    backgroundColor: '#00C752',
+    marginTop: '10px',
+    '&:hover': {
+      cursor: 'pointer',
+    },
   },
   icon: {
     marginRight: '12px',
@@ -46,12 +74,35 @@ const localStyles = stylesheet({
     padding: '10px 0px 10px 0px',
   },
   queryTime: {
-    width: '100px',
+    width: '85px',
     color: 'gray',
   },
   openDetails: {
     marginBottom: '10px',
-    padding: '12px',
+    padding: '14px',
+  },
+  openQueryButton: {
+    display: 'flex',
+    alignItems: 'center',
+    border: 'var(--jp-border-width) solid var(--jp-border-color2)',
+    backgroundColor: 'white',
+    '&:hover': {
+      boxShadow: '1px 1px 3px 0px rgba(0,0,0,0.5)',
+      cursor: 'pointer',
+    },
+  },
+  openQueryButtonSmall: {
+    border: 'var(--jp-border-width) solid white',
+    backgroundColor: 'white',
+    '&:hover': {
+      border: 'var(--jp-border-width) solid var(--jp-border-color2)',
+      cursor: 'pointer',
+    },
+  },
+  detailsTopArea: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginBottom: '14px',
   },
 });
 
@@ -63,53 +114,167 @@ interface Props {
 interface State {
   hasLoaded: boolean;
   isLoading: boolean;
-  jobIds: JobIdsObject;
+  jobIds: string[];
   jobs: JobsObject;
   openJob: string;
 }
 
-const QueryDetails = props => {
-  const job = props.details;
+const ErrorBox = (props: { errorMsg: string }) => {
+  return (
+    <Paper
+      style={{
+        display: 'flex',
+        alignItems: 'stretch',
+        marginBottom: '12px',
+      }}
+      elevation={1}
+      variant="outlined"
+    >
+      <div style={{ width: '6px', backgroundColor: '#e60000' }} />
+      <div style={{ padding: '8px', display: 'flex', alignItems: 'center' }}>
+        <Error
+          fontSize="default"
+          htmlColor="rgb(230, 0, 0)"
+          className={localStyles.icon}
+        />
+        {props.errorMsg}
+      </div>
+    </Paper>
+  );
+};
+
+const QueryDetails = (props: { job: Job }) => {
+  const { details, created, errored, query } = props.job;
   const rows = [
-    { name: 'Job ID', value: `${job.project}:${job.location}.${job.id}` },
-    { name: 'User', value: job.user },
-    { name: 'Location', value: job.location },
-    { name: 'Creation time', value: job.created },
-    { name: 'Start time', value: job.started },
-    { name: 'End time', value: job.ended },
+    {
+      name: 'Job ID',
+      value: `${details.project}:${details.location}.${details.id}`,
+    },
+    { name: 'User', value: details.user },
+    { name: 'Location', value: details.location },
+    { name: 'Creation time', value: formatDate(details.created) },
+    { name: 'Start time', value: formatDate(details.started) },
+    { name: 'End time', value: formatDate(details.ended) },
     {
       name: 'Duration',
-      value: job.duration ? `${job.duration.toFixed(2)} sec` : '0.0 sec',
+      value: details.duration
+        ? `${details.duration.toFixed(1)} sec`
+        : '0.0 sec',
     },
     {
       name: 'Bytes processed',
-      value: job.bytesProcessed
-        ? formatBytes(job.bytesProcessed, 2)
-        : job.from_cache
+      value: details.bytesProcessed
+        ? formatBytes(details.bytesProcessed, 2)
+        : details.from_cache
         ? '0 B (results cached)'
         : '0 B',
     },
-    { name: 'Job priority', value: job.priority },
-    { name: 'Destination table', value: job.destination },
-    { name: 'Use legacy SQL', value: job.useLegacySql ? 'true' : 'false' },
+    { name: 'Job priority', value: details.priority },
+    { name: 'Destination table', value: details.destination },
+    { name: 'Use legacy SQL', value: details.useLegacySql ? 'true' : 'false' },
   ];
-  return <StripedRows rows={rows} />;
-};
-
-const QueryStatus = props => {
-  const failed = props.failed;
   return (
-    <div
-      style={{
-        padding: '10px 12px 10px 12px',
-        color: 'white',
-        backgroundColor: failed ? '#DA4336' : '#00C752',
-        marginTop: '10px',
-      }}
-    >
-      {failed ? 'Query failed' : 'Query succeeded'}
+    <div>
+      <div className={localStyles.detailsTopArea}>
+        <div>
+          {!errored && `Query completed in ${details.duration.toFixed(3)} sec`}
+          <div className={localStyles.queryTime}>{formatTime(created)}</div>
+        </div>
+        <button
+          className={localStyles.openQueryButton}
+          onClick={() => {
+            const queryId = generateQueryId();
+            WidgetManager.getInstance().launchWidget(
+              QueryEditorTabWidget,
+              'main',
+              queryId,
+              undefined,
+              [queryId, query]
+            );
+          }}
+        >
+          <Icon
+            style={{
+              display: 'flex',
+              alignContent: 'center',
+            }}
+            color="primary"
+          >
+            <div className={'jp-Icon jp-Icon-20 jp-OpenEditorIcon'} />
+          </Icon>
+          Open query in editor
+        </button>
+      </div>
+
+      {errored && <ErrorBox errorMsg={details.errorResult.message} />}
+
+      <div style={{ marginBottom: '12px' }}>
+        <ReadOnlyEditor query={query} />
+      </div>
+
+      <StripedRows rows={rows} />
     </div>
   );
+};
+
+// clickable bar when query details are not open
+const QueryBar = (props: { jobs: JobsObject; jobId: string }) => {
+  const { jobs, jobId } = props;
+  return (
+    <div className={localStyles.queryBar}>
+      <div className={localStyles.queryTime}>
+        {formatTime(jobs[jobId].created)}
+      </div>
+      {jobs[jobId].errored ? (
+        <Error
+          fontSize="inherit"
+          htmlColor="rgb(230, 0, 0)"
+          className={localStyles.icon}
+        />
+      ) : (
+        <CheckCircle
+          fontSize="inherit"
+          htmlColor="rgb(0, 199, 82)"
+          className={localStyles.icon}
+        />
+      )}
+      <div className={localStyles.query}>{jobs[jobId].query}</div>
+      <button
+        className={localStyles.openQueryButtonSmall}
+        onClick={() => {
+          const queryId = generateQueryId();
+          WidgetManager.getInstance().launchWidget(
+            QueryEditorTabWidget,
+            'main',
+            queryId,
+            undefined,
+            [queryId, jobs[jobId].query]
+          );
+        }}
+      >
+        <Icon
+          style={{
+            display: 'flex',
+            alignContent: 'center',
+          }}
+        >
+          <div className={'jp-Icon jp-Icon-20 jp-OpenEditorIcon'} />
+        </Icon>
+      </button>
+    </div>
+  );
+};
+
+// clickable bar when query details are open
+const QueryStatus = props => {
+  const failed = props.failed;
+  if (failed) {
+    return <div className={localStyles.queryStatusBarFailed}>Query failed</div>;
+  } else {
+    return (
+      <div className={localStyles.queryStatusBarSucceeded}>Query succeeded</div>
+    );
+  }
 };
 
 class QueryHistoryPanel extends React.Component<Props, State> {
@@ -119,7 +284,7 @@ class QueryHistoryPanel extends React.Component<Props, State> {
       hasLoaded: false,
       isLoading: false,
       jobs: {} as JobsObject,
-      jobIds: {} as JobIdsObject,
+      jobIds: [],
       openJob: null,
     };
   }
@@ -150,6 +315,20 @@ class QueryHistoryPanel extends React.Component<Props, State> {
     }
   };
 
+  processHistory = (jobIds, jobs) => {
+    const queriesByDate = {};
+    jobIds.map(jobId => {
+      const date = DateTime.fromISO(jobs[jobId].created);
+      const day = date.toLocaleString(DateTime.DATE_SHORT);
+      if (day in queriesByDate) {
+        queriesByDate[day].push(jobId);
+      } else {
+        queriesByDate[day] = [jobId];
+      }
+    });
+    return queriesByDate;
+  };
+
   private async getHistory() {
     try {
       this.setState({ isLoading: true });
@@ -167,22 +346,14 @@ class QueryHistoryPanel extends React.Component<Props, State> {
     }
   }
 
-  formatDateString(date) {
-    return `${date.getMonth() + 1}/${date.getDate()}/${date
-      .getFullYear()
-      .toString()
-      .slice(-2)}`;
-  }
-
   displayDate(date) {
-    const today = new Date();
-    const todayString = this.formatDateString(today);
-    const yesterday = new Date(today.setDate(today.getDate() - 1));
-    const yesterdayString = this.formatDateString(yesterday);
-
-    if (date === todayString) {
+    const today = DateTime.local().toLocaleString(DateTime.DATE_SHORT);
+    const yesterday = DateTime.local()
+      .minus({ days: 1 })
+      .toLocaleString(DateTime.DATE_SHORT);
+    if (date === today) {
       return 'Today';
-    } else if (date === yesterdayString) {
+    } else if (date === yesterday) {
       return 'Yesterday';
     } else {
       return date;
@@ -197,11 +368,14 @@ class QueryHistoryPanel extends React.Component<Props, State> {
         </>
       );
     } else {
+      const { jobs, jobIds, openJob } = this.state;
+      const queriesByDate = this.processHistory(jobIds, jobs);
+
       return (
         <div style={{ height: '100%' }}>
           <Header text="Query history" />
           <div className={localStyles.body}>
-            {Object.keys(this.state.jobIds).map(date => {
+            {Object.keys(queriesByDate).map(date => {
               return (
                 <div
                   className={localStyles.dateGroup}
@@ -212,52 +386,27 @@ class QueryHistoryPanel extends React.Component<Props, State> {
                       {this.displayDate(date)}
                     </div>
                   </Paper>
-                  {this.state.jobIds[date].map(jobId => {
+                  {queriesByDate[date].map(jobId => {
                     return (
-                      <div key={jobId}>
+                      <div key={`query_details_${jobId}`}>
                         <div
-                          onClick={event => {
+                          onClick={() => {
                             this.setState({
-                              openJob:
-                                this.state.openJob === jobId ? null : jobId,
+                              openJob: openJob === jobId ? null : jobId,
                             });
                             this.getQueryDetails(jobId);
                           }}
                         >
-                          {this.state.openJob === jobId ? (
-                            <QueryStatus
-                              failed={this.state.jobs[jobId].errored}
-                            />
+                          {openJob === jobId ? (
+                            <QueryStatus failed={jobs[jobId].errored} />
                           ) : (
-                            <div className={localStyles.queryBar}>
-                              <div className={localStyles.queryTime}>
-                                {this.state.jobs[jobId].time}
-                              </div>
-                              {this.state.jobs[jobId].errored ? (
-                                <Error
-                                  fontSize="inherit"
-                                  htmlColor="rgb(230, 0, 0)"
-                                  className={localStyles.icon}
-                                />
-                              ) : (
-                                <CheckCircle
-                                  fontSize="inherit"
-                                  htmlColor="rgb(0, 199, 82)"
-                                  className={localStyles.icon}
-                                />
-                              )}
-                              <div className={localStyles.query}>
-                                {this.state.jobs[jobId].query}
-                              </div>
-                            </div>
+                            <QueryBar jobId={jobId} jobs={jobs} />
                           )}
                         </div>
-                        <Collapse in={this.state.openJob === jobId}>
-                          {this.state.jobs[jobId].details ? (
+                        <Collapse in={openJob === jobId}>
+                          {jobs[jobId].details ? (
                             <Paper square className={localStyles.openDetails}>
-                              <QueryDetails
-                                details={this.state.jobs[jobId].details}
-                              />
+                              <QueryDetails job={jobs[jobId]} />
                             </Paper>
                           ) : (
                             <LinearProgress />

--- a/jupyterlab_bigquery/src/components/query_history/service/query_history.ts
+++ b/jupyterlab_bigquery/src/components/query_history/service/query_history.ts
@@ -3,7 +3,7 @@ import { URLExt } from '@jupyterlab/coreutils';
 
 interface QueryHistory {
   jobs: JobsObject;
-  jobIds: JobIdsObject;
+  jobIds: string[];
 }
 
 export interface JobIdsObject {
@@ -14,7 +14,7 @@ export interface JobsObject {
   [key: string]: Job;
 }
 
-interface JobDetailsObject {
+export interface JobDetailsObject {
   query: string;
   id: string;
   user: string;
@@ -28,17 +28,22 @@ interface JobDetailsObject {
   destination: string;
   useLegacySql: boolean;
   state: string;
-  errors: string[];
-  errorResult: string;
+  errors: ErrorResult[];
+  errorResult: ErrorResult;
   from_cache: boolean;
   project: string;
 }
 
-interface Job {
+interface ErrorResult {
+  location: string;
+  message: string;
+  reason: string;
+}
+
+export interface Job {
   query: string;
   id: string;
   created: string;
-  time: string;
   errored: boolean;
   details?: JobDetailsObject;
 }

--- a/jupyterlab_bigquery/src/components/shared/read_only_editor.tsx
+++ b/jupyterlab_bigquery/src/components/shared/read_only_editor.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { Paper } from '@material-ui/core';
+import Editor from '@monaco-editor/react';
+import { monaco } from '@monaco-editor/react';
+import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
+
+function handleEditorDidMount(_, editor) {
+  const editorElement = editor.getDomNode();
+  if (!editorElement) {
+    return;
+  }
+
+  monaco
+    .init()
+    .then(monaco => {
+      const lineHeight = editor.getOption(
+        monaco.editor.EditorOption.lineHeight
+      );
+      const lineCount = editor._modelData.viewModel.getLineCount();
+      const height = lineCount * lineHeight;
+      editorElement.style.height = `${height + 0.5 * lineHeight}px`;
+      editor.layout();
+
+      monaco.editor.defineTheme('viewOnlyQueryTheme', {
+        base: 'vs',
+        inherit: true,
+        rules: [],
+        colors: {
+          'editorCursor.foreground': '#FFFFFF',
+          'editorGutter.background': '#f8f9fa',
+        },
+      });
+      monaco.editor.setTheme('viewOnlyQueryTheme');
+    })
+    .catch(error =>
+      console.error(
+        'An error occurred during initialization of Monaco: ',
+        error
+      )
+    );
+}
+
+const READ_ONLY_SQL_EDITOR_OPTIONS: editor.IEditorConstructionOptions = {
+  lineNumbers: 'on',
+  minimap: { enabled: false },
+  readOnly: true,
+  cursorStyle: 'line-thin',
+  renderLineHighlight: 'none',
+  overviewRulerLanes: 0,
+  overviewRulerBorder: false,
+  hideCursorInOverviewRuler: true,
+  matchBrackets: 'never',
+  occurrencesHighlight: false,
+  folding: false,
+  scrollBeyondLastLine: false,
+};
+
+const ReadOnlyEditor = props => {
+  return (
+    <Paper variant="outlined">
+      <Editor
+        width="100%"
+        theme={'vs'}
+        language={'sql'}
+        value={props.query}
+        options={READ_ONLY_SQL_EDITOR_OPTIONS}
+        editorDidMount={handleEditorDidMount}
+      />
+    </Paper>
+  );
+};
+
+export default ReadOnlyEditor;

--- a/jupyterlab_bigquery/src/utils/formatters.ts
+++ b/jupyterlab_bigquery/src/utils/formatters.ts
@@ -4,3 +4,8 @@ export function formatDate(dateString) {
   const date = DateTime.fromISO(dateString);
   return date.toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
 }
+
+export function formatTime(dateString) {
+  const date = DateTime.fromISO(dateString);
+  return date.toLocaleString(DateTime.TIME_SIMPLE);
+}

--- a/jupyterlab_bigquery/style/images/open_editor_20px.svg
+++ b/jupyterlab_bigquery/style/images/open_editor_20px.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 39 (31667) - http://www.bohemiancoding.com/sketch -->
+    <title>20/open-editor</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="All-Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="20/open-editor">
+            <polygon id="Container" points="0 0 20 0 20 20 0 20"></polygon>
+            <path d="M13,17 L14.9941413,17 C16.1029399,17 17,16.1019465 17,14.9941413 L17,5.00585866 C17,3.89706013 16.1019465,3 14.9941413,3 L5.00585866,3 C3.89706013,3 3,3.89805351 3,5.00585866 L3,14.9941413 C3,16.1029399 3.89805351,17 5.00585866,17 L7,17 L5,15 L5,7 L15,7 L15,15 L13,17 Z M9,8 L11,8 L11,13 L9,13 L9,8 Z M10,17 L14,13 L6,13 L10,17 Z" id="Open-Copy" fill="#000000"></path>
+        </g>
+    </g>
+</svg>

--- a/jupyterlab_bigquery/style/images/open_editor_24px.svg
+++ b/jupyterlab_bigquery/style/images/open_editor_24px.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+    <title>24/open-editor</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="24/open-editor" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <polygon id="Container" points="0 0 24 0 24 24 0 24"></polygon>
+        <path d="M5,4 C3.89,4 3,4.9 3,6 L3,18 C3,19.1 3.89,20 5,20 L9,20 L7,18 L5,18 L5,8 L19,8 L19,18 L17,18 L15,20 L19,20 C20.1,20 21,19.1 21,18 L21,6 C21,4.9 20.11,4 19,4 L5,4 Z M12,20 L8,16 L11,16 L11,10 L13,10 L13,16 L16,16 L12,20 L12,20 Z" id="Shape" fill="#000000"></path>
+    </g>
+</svg>

--- a/jupyterlab_bigquery/style/index.css
+++ b/jupyterlab_bigquery/style/index.css
@@ -18,6 +18,10 @@
   background-image: url('./images/model_20px.svg');
   background-size: contain;
 }
+.jp-OpenEditorIcon {
+  background-image: url('./images/open_editor_20px.svg');
+  background-size: contain;
+}
 .jp-OutputArea-child .jp-OutputArea-output {
   overflow: auto;
 }


### PR DESCRIPTION
- Pulls out shared read-only editor (between details panel and expanded query history)
- Batches query history by date on the frontend with local timezone accounted for
- Can open old query in a full-window editor
- Adds indication of what caused an error for failed queries
- Adds extra test for query details with an error

A copy to clipboard button will be added in a future PR.

Successful query:
![success](https://user-images.githubusercontent.com/48393093/89934895-4597fd00-dbdf-11ea-8439-0c72509a7fb5.png)

Failed query:
![failed](https://user-images.githubusercontent.com/48393093/89934909-492b8400-dbdf-11ea-9cec-0d5c50b11f81.png)
