### PR TITLE
[BigQuery] Change fonts to roboto and pull out shared tables

### DIFF
--- a/jupyterlab_bigquery/src/components/details_panel/dataset_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/dataset_details_panel.tsx
@@ -9,6 +9,7 @@ import LoadingPanel from '../loading_panel';
 import { DetailsPanel } from './details_panel';
 import { stylesheet } from 'typestyle';
 import { formatDate } from '../../utils/formatters';
+import { BASE_FONT } from 'gcp_jupyterlab_shared';
 
 export const localStyles = stylesheet({
   body: {
@@ -23,6 +24,7 @@ export const localStyles = stylesheet({
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
+    ...BASE_FONT,
   },
 });
 

--- a/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
@@ -1,21 +1,13 @@
 import * as React from 'react';
 
-import {
-  Grid,
-  Chip,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  withStyles,
-} from '@material-ui/core';
+import { Grid, Chip, withStyles } from '@material-ui/core';
 import { stylesheet } from 'typestyle';
 
 import ReadOnlyEditor from '../shared/read_only_editor';
 import { SchemaField } from './service/list_table_details';
 import { ModelSchema } from './service/list_model_details';
 import { StripedRows } from '../shared/striped_rows';
+import { SchemaTable, ModelSchemaTable } from '../shared/schema_table';
 
 export const localStyles = stylesheet({
   title: {
@@ -42,19 +34,16 @@ export const localStyles = stylesheet({
     },
   },
   rowTitle: {
-    width: '200px',
+    width: '150px',
   },
   row: {
     display: 'flex',
     padding: '6px',
   },
-});
-
-export const TableHeadCell: React.ComponentType<any> = withStyles({
-  root: {
-    backgroundColor: '#f0f0f0',
+  bold: {
+    fontWeight: 500,
   },
-})(TableCell);
+});
 
 const StyledChip = withStyles({
   root: {
@@ -62,20 +51,6 @@ const StyledChip = withStyles({
     backgroundColor: 'rgba(25, 103, 210, 0.1)',
   },
 })(Chip);
-
-const formatFieldName = name => {
-  if (name.includes('.')) {
-    const child = name.substr(name.lastIndexOf('.') + 1);
-    const parents = name.substr(0, name.lastIndexOf('.') + 1);
-    return (
-      <div>
-        {parents} <b>{child}</b>
-      </div>
-    );
-  } else {
-    return <b>{name}</b>;
-  }
-};
 
 interface SharedDetails {
   id: string;
@@ -149,31 +124,7 @@ export const DetailsPanel: React.SFC<Props> = props => {
               Schema
             </div>
             {details.schema && details.schema.length > 0 ? (
-              <Table
-                size="small"
-                style={{ width: 'auto', tableLayout: 'auto' }}
-              >
-                <TableHead>
-                  <TableRow>
-                    <TableHeadCell>Field name</TableHeadCell>
-                    <TableHeadCell>Type</TableHeadCell>
-                    <TableHeadCell>Mode</TableHeadCell>
-                    <TableHeadCell>Description</TableHeadCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {details.schema.map((field, index) => {
-                    return (
-                      <TableRow key={`schema_row_${index}`}>
-                        <TableCell>{formatFieldName(field.name)}</TableCell>
-                        <TableCell>{field.type}</TableCell>
-                        <TableCell>{field.mode}</TableCell>
-                        <TableCell>{field.description ?? ''}</TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
+              <SchemaTable schema={details.schema} />
             ) : (
               'Table does not have a schema.'
             )}
@@ -196,27 +147,7 @@ export const DetailsPanel: React.SFC<Props> = props => {
             </div>
             <div>
               {details.schema_labels && details.schema_labels.length > 0 ? (
-                <Table
-                  size="small"
-                  style={{ width: 'auto', tableLayout: 'auto' }}
-                >
-                  <TableHead>
-                    <TableRow>
-                      <TableHeadCell>Field name</TableHeadCell>
-                      <TableHeadCell>Type</TableHeadCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {details.schema_labels.map((field, index) => {
-                      return (
-                        <TableRow key={`schema_label_row_${index}`}>
-                          <TableCell>{field.name}</TableCell>
-                          <TableCell>{field.type}</TableCell>
-                        </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
+                <ModelSchemaTable schema={details.schema_labels} />
               ) : (
                 'Model does not have any label columns.'
               )}
@@ -227,27 +158,7 @@ export const DetailsPanel: React.SFC<Props> = props => {
             </div>
             <div>
               {details.feature_columns && details.feature_columns.length > 0 ? (
-                <Table
-                  size="small"
-                  style={{ width: 'auto', tableLayout: 'auto' }}
-                >
-                  <TableHead>
-                    <TableRow>
-                      <TableHeadCell>Field name</TableHeadCell>
-                      <TableHeadCell>Type</TableHeadCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {details.feature_columns.map((field, index) => {
-                      return (
-                        <TableRow key={`schema_feature_row_${index}`}>
-                          <TableCell>{field.name}</TableCell>
-                          <TableCell>{field.type}</TableCell>
-                        </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
+                <ModelSchemaTable schema={details.feature_columns} />
               ) : (
                 'Model does not have any feature columns.'
               )}

--- a/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
@@ -15,6 +15,7 @@ import { QueryEditorTabWidget } from '../query_editor/query_editor_tab/query_edi
 import { WidgetManager } from '../../utils/widgetManager/widget_manager';
 import { generateQueryId } from '../../reducers/queryEditorTabSlice';
 import { stylesheet } from 'typestyle';
+import { BASE_FONT } from 'gcp_jupyterlab_shared';
 
 export const localStyles = stylesheet({
   body: {
@@ -25,6 +26,12 @@ export const localStyles = stylesheet({
     minHeight: 0,
     display: 'flex',
     flexDirection: 'column',
+  },
+  tableDetailsRoot: {
+    display: 'flex',
+    flexFlow: 'column',
+    height: '100%',
+    ...BASE_FONT,
   },
 });
 
@@ -74,7 +81,7 @@ export default class TableDetailsTabs extends React.Component<Props, State> {
       return <LoadingPanel />;
     } else {
       return (
-        <div style={{ display: 'flex', flexFlow: 'column', height: '100%' }}>
+        <div className={localStyles.tableDetailsRoot}>
           <Header
             text={this.props.table_name}
             buttons={[

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
@@ -39,7 +39,7 @@ import {
   SearchResult,
 } from '../list_items_panel/service/search_items';
 import { SearchBar } from './search_bar';
-import { DialogComponent, COLORS } from 'gcp_jupyterlab_shared';
+import { DialogComponent, COLORS, BASE_FONT } from 'gcp_jupyterlab_shared';
 import CustomSnackbar from './snackbar';
 
 interface Props {
@@ -83,7 +83,6 @@ const localStyles = stylesheet({
   header: {
     borderBottom: 'var(--jp-border-width) solid var(--jp-border-color2)',
     fontWeight: 600,
-    fontFamily: 'var(--jp-ui-font-family)',
     fontSize: 'var(--jp-ui-font-size0, 11px)',
     letterSpacing: '1px',
     margin: 0,
@@ -107,7 +106,6 @@ const localStyles = stylesheet({
   },
   resourcesTitle: {
     fontWeight: 600,
-    fontFamily: 'var(--jp-ui-font-family)',
     fontSize: 'var(--jp-ui-font-size0, 11px)',
     letterSpacing: '1px',
     margin: 0,
@@ -134,7 +132,6 @@ const localStyles = stylesheet({
   },
   buttonLabel: {
     fontWeight: 400,
-    fontFamily: 'var(--jp-ui-font-family)',
     fontSize: 'var(--jp-ui-font-size1)',
     textTransform: 'initial',
     overflow: 'hidden',
@@ -183,9 +180,8 @@ const localStyles = stylesheet({
   },
   panel: {
     backgroundColor: 'white',
-    //color: COLORS.base,
     height: '100%',
-    //...BASE_FONT,
+    ...BASE_FONT,
     ...csstips.vertical,
   },
   enableSearch: {

--- a/jupyterlab_bigquery/src/components/query_editor/query_editor_incell/query_editor_incell.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_editor_incell/query_editor_incell.tsx
@@ -10,6 +10,14 @@ import {
 } from '../../../reducers/queryEditorTabSlice';
 import { DOMWidgetView } from '@jupyter-widgets/base';
 import ReactResizeDetector from 'react-resize-detector';
+import { stylesheet } from 'typestyle';
+import { BASE_FONT } from 'gcp_jupyterlab_shared';
+
+const localStyles = stylesheet({
+  inCellEditorRoot: {
+    ...BASE_FONT,
+  },
+});
 
 interface QueryEditorInCellProps {
   queries: { [key: string]: QueryResult };
@@ -44,7 +52,7 @@ export class QueryEditorInCell extends Component<QueryEditorInCellProps, {}> {
       <ReactResizeDetector>
         {({ width }) => {
           return (
-            <div>
+            <div className={localStyles.inCellEditorRoot}>
               <QueryTextEditor
                 queryId={this.queryId}
                 iniQuery={this.iniQuery}

--- a/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab.tsx
@@ -5,6 +5,18 @@ import {
   QueryId,
   generateQueryId,
 } from '../../../reducers/queryEditorTabSlice';
+import { stylesheet } from 'typestyle';
+import { BASE_FONT } from 'gcp_jupyterlab_shared';
+
+const localStyles = stylesheet({
+  queryTextEditorRoot: {
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    height: '100%',
+    ...BASE_FONT,
+  },
+});
 
 interface QueryEditorTabProps {
   isVisible: boolean;
@@ -27,14 +39,7 @@ class QueryEditorTab extends React.Component<QueryEditorTabProps, {}> {
 
   render() {
     return (
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-          height: '100%',
-        }}
-      >
+      <div className={localStyles.queryTextEditorRoot}>
         <QueryTextEditor
           queryId={this.queryId}
           iniQuery={this.props.iniQuery}

--- a/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
+++ b/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
@@ -19,8 +19,13 @@ import { QueryEditorTabWidget } from '../query_editor/query_editor_tab/query_edi
 import { WidgetManager } from '../../utils/widgetManager/widget_manager';
 import { generateQueryId } from '../../reducers/queryEditorTabSlice';
 import { formatTime, formatDate } from '../../utils/formatters';
+import { BASE_FONT } from 'gcp_jupyterlab_shared';
 
 const localStyles = stylesheet({
+  queryHistoryRoot: {
+    height: '100%',
+    ...BASE_FONT,
+  },
   body: {
     height: '100%',
     overflowY: 'auto',
@@ -372,7 +377,7 @@ class QueryHistoryPanel extends React.Component<Props, State> {
       const queriesByDate = this.processHistory(jobIds, jobs);
 
       return (
-        <div style={{ height: '100%' }}>
+        <div className={localStyles.queryHistoryRoot}>
           <Header text="Query history" />
           <div className={localStyles.body}>
             {Object.keys(queriesByDate).map(date => {

--- a/jupyterlab_bigquery/src/components/shared/bq_table.tsx
+++ b/jupyterlab_bigquery/src/components/shared/bq_table.tsx
@@ -17,11 +17,9 @@ import {
   LastPage,
 } from '@material-ui/icons';
 
+import { TableHeadCell } from './schema_table';
+
 const localStyles = stylesheet({
-  tableHeader: {
-    backgroundColor: '#f0f0f0',
-    color: 'black',
-  },
   tableCell: {
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
@@ -147,10 +145,10 @@ export class BQTable extends React.Component<Props, State> {
       <>
         <div className={localStyles.scrollable}>
           <Table size="small" style={{ width: 'auto', tableLayout: 'auto' }}>
-            <TableHead className={localStyles.tableHeader}>
+            <TableHead>
               <TableRow>
                 {fields.map((field, index) => (
-                  <TableCell key={'field_' + index}>{field}</TableCell>
+                  <TableHeadCell key={'field_' + index}>{field}</TableHeadCell>
                 ))}
               </TableRow>
             </TableHead>

--- a/jupyterlab_bigquery/src/components/shared/schema_table.tsx
+++ b/jupyterlab_bigquery/src/components/shared/schema_table.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import { stylesheet } from 'typestyle';
+
+import {
+  Table,
+  TableHead,
+  TableRow,
+  TableBody,
+  TableCell,
+  withStyles,
+} from '@material-ui/core';
+
+import { BASE_FONT } from 'gcp_jupyterlab_shared';
+
+export const localStyles = stylesheet({
+  bold: {
+    fontWeight: 500,
+  },
+});
+
+export const TableHeadCell: React.ComponentType<any> = withStyles({
+  root: {
+    backgroundColor: '#f8f9fa',
+    whiteSpace: 'nowrap',
+    fontSize: '13px',
+    padding: '4px 16px 4px 16px',
+    borderTop: '1px  solid var(--jp-border-color2)',
+    BASE_FONT,
+  },
+})(TableCell);
+
+const formatFieldName = name => {
+  if (name.includes('.')) {
+    const child = name.substr(name.lastIndexOf('.') + 1);
+    const parents = name.substr(0, name.lastIndexOf('.') + 1);
+    return (
+      <div>
+        <span style={{ color: 'gray' }}>{parents}</span>{' '}
+        <span className={localStyles.bold}>{child}</span>
+      </div>
+    );
+  } else {
+    return <div className={localStyles.bold}>{name}</div>;
+  }
+};
+
+const StyledTableCell = withStyles({
+  root: {
+    fontSize: '13px',
+    BASE_FONT,
+  },
+})(TableCell);
+
+export const SchemaTable = (props: { schema: any }) => {
+  return (
+    <Table size="small" style={{ width: 'auto', tableLayout: 'auto' }}>
+      <TableHead>
+        <TableRow>
+          <TableHeadCell>Field name</TableHeadCell>
+          <TableHeadCell>Type</TableHeadCell>
+          <TableHeadCell>Mode</TableHeadCell>
+          <TableHeadCell>Description</TableHeadCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {props.schema.map((field, index) => {
+          return (
+            <TableRow key={`schema_row_${index}`}>
+              <StyledTableCell>{formatFieldName(field.name)}</StyledTableCell>
+              <StyledTableCell>{field.type}</StyledTableCell>
+              <StyledTableCell>{field.mode}</StyledTableCell>
+              <StyledTableCell>{field.description ?? ''}</StyledTableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+};
+
+export const ModelSchemaTable = (props: { schema: any }) => {
+  return (
+    <Table size="small" style={{ width: 'auto', tableLayout: 'auto' }}>
+      <TableHead>
+        <TableRow>
+          <TableHeadCell>Field name</TableHeadCell>
+          <TableHeadCell>Type</TableHeadCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {props.schema.map((field, index) => {
+          return (
+            <TableRow key={`schema_row_${index}`}>
+              <StyledTableCell>{formatFieldName(field.name)}</StyledTableCell>
+              <StyledTableCell>{field.type}</StyledTableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+};

--- a/jupyterlab_bigquery/src/components/shared/striped_rows.tsx
+++ b/jupyterlab_bigquery/src/components/shared/striped_rows.tsx
@@ -9,6 +9,9 @@ const localStyles = stylesheet({
   rowTitle: {
     width: '200px',
   },
+  bold: {
+    fontWeight: 500,
+  },
 });
 
 export const getStripedStyle = index => {
@@ -25,7 +28,7 @@ export const StripedRows = props => {
           style={{ ...getStripedStyle(index) }}
         >
           <div className={localStyles.rowTitle}>
-            <b>{row.name}</b>
+            <div className={localStyles.bold}>{row.name}</div>
           </div>
           <div>{row.value}</div>
         </div>


### PR DESCRIPTION
Changes all the fonts to roboto by importing them from the shared package. It may eventually make more sense to have an overall material UI theme and use a `ThemeProvider` rather than styling all the shared material UI components, but seeing as we have to set the font within each of the widgets already, it is a little simpler this way.