### PR TITLE
Move StripedRows to shared

### DIFF
--- a/jupyterlab_bigquery/package.json
+++ b/jupyterlab_bigquery/package.json
@@ -66,7 +66,7 @@
     "@reduxjs/toolkit": "^1.4.0",
     "copy-to-clipboard": "^3.3.1",
     "csstips": "1.2.0",
-    "gcp_jupyterlab_shared": "^1.0.0",
+    "gcp_jupyterlab_shared": "^1.0.6",
     "luxon": "^1.24.1",
     "monaco-editor": "^0.20.0",
     "react-redux": "^7.2.0",

--- a/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
@@ -6,8 +6,8 @@ import { stylesheet } from 'typestyle';
 import ReadOnlyEditor from '../shared/read_only_editor';
 import { SchemaField } from './service/list_table_details';
 import { ModelSchema } from './service/list_model_details';
-import { StripedRows } from '../shared/striped_rows';
 import { SchemaTable, ModelSchemaTable } from '../shared/schema_table';
+import { StripedRows } from 'gcp_jupyterlab_shared';
 
 export const localStyles = stylesheet({
   title: {

--- a/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
+++ b/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
@@ -11,7 +11,7 @@ import {
 } from './service/query_history';
 import { Header } from '../shared/header';
 import LoadingPanel from '../loading_panel';
-import { StripedRows } from '../shared/striped_rows';
+import { StripedRows } from 'gcp_jupyterlab_shared';
 import ReadOnlyEditor from '../shared/read_only_editor';
 import { JobsObject, Job } from './service/query_history';
 import { QueryEditorTabWidget } from '../query_editor/query_editor_tab/query_editor_tab_widget';

--- a/shared/src/components/striped_rows.tsx
+++ b/shared/src/components/striped_rows.tsx
@@ -14,7 +14,7 @@ const localStyles = stylesheet({
   },
 });
 
-export const getStripedStyle = index => {
+const getStripedStyle = index => {
   return { background: index % 2 ? 'white' : '#fafafa' };
 };
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -27,6 +27,7 @@ export * from './components/message';
 export * from './components/progress';
 export * from './components/select_input';
 export * from './components/status_icons';
+export * from './components/striped_rows';
 export * from './components/submit_button';
 export * from './components/text_input';
 export * from './components/toggle_switch_input';


### PR DESCRIPTION
Takes `jupyerlab_bigquery/src/shared/striped_rows` and makes it into a shared component. Would likely be reused by the uCAIP extension which has a similar details panel to BigQuery.