### PR TITLE
[HardwareConfiguration] Adding error handling in rescaling dialog

### DIFF
--- a/jupyterlab_gcedetails/src/components/confirmation_page.tsx
+++ b/jupyterlab_gcedetails/src/components/confirmation_page.tsx
@@ -19,7 +19,7 @@ import * as React from 'react';
 
 import { BASE_FONT, Message } from 'gcp_jupyterlab_shared';
 import { stylesheet, classes } from 'typestyle';
-import { HardwareConfiguration, ACCELERATOR_TYPES } from '../data';
+import { HardwareConfiguration, getGpuTypeText } from '../data';
 import { HardwareConfigurationDescription } from './hardware_scaling_form';
 import { ActionBar } from './action_bar';
 
@@ -58,10 +58,6 @@ export const STYLES = stylesheet({
 
 const INFO_MESSAGE = `Updating your configuration will take 5-10 minutes. During this time you will not be able to access your notebook instance.
   If you have chosen to attach GPUs to your instance, the NVIDIA GPU driver will be installed automatically on the next startup.`;
-
-function getGpuTypeText(value: string) {
-  return ACCELERATOR_TYPES.find(option => option.value === value).text;
-}
 
 function displayConfiguration(
   configuration: HardwareConfiguration,

--- a/jupyterlab_gcedetails/src/components/details_dialog_body.tsx
+++ b/jupyterlab_gcedetails/src/components/details_dialog_body.tsx
@@ -15,9 +15,9 @@
  */
 
 import * as React from 'react';
-import { ActionBar, SubmitButton } from 'gcp_jupyterlab_shared';
 import { stylesheet } from 'typestyle';
 import { MAPPED_ATTRIBUTES, Details, STYLES } from '../data';
+import { ActionBar } from './action_bar';
 
 const DETAILS_STYLES = stylesheet({
   container: {
@@ -50,13 +50,12 @@ export function DetailsDialogBody(props: Props) {
               <dd className={STYLES.dd}>{am.mapper(details)}</dd>
             </div>
           ))}
-      <ActionBar closeLabel="Close" onClick={onDialogClose}>
-        <SubmitButton
-          actionPending={false}
-          onClick={reshapeForm}
-          text="Reshape"
-        />
-      </ActionBar>
+      <ActionBar
+        primaryLabel="Reshape"
+        onPrimaryClick={reshapeForm}
+        secondaryLabel="Close"
+        onSecondaryClick={onDialogClose}
+      />
     </dl>
   );
 }

--- a/jupyterlab_gcedetails/src/components/error_page.tsx
+++ b/jupyterlab_gcedetails/src/components/error_page.tsx
@@ -51,7 +51,7 @@ export const STYLES = stylesheet({
     paddingTop: '15px',
   },
   infoMessage: {
-    margin: '20px 16px 0px 16px',
+    margin: '20px 16px 16px 16px',
   },
 });
 
@@ -60,7 +60,6 @@ const LINK = `https://console.cloud.google.com/ai-platform/notebooks/`;
 const LINK_TEXT = `View Cloud Console`;
 
 function displayInstance(instance: Instance) {
-  console.log('display instance');
   const { machineType, acceleratorConfig } = instance;
   const machineTypeText = getMachineTypeText(machineType.split('/').pop());
 

--- a/jupyterlab_gcedetails/src/components/error_page.tsx
+++ b/jupyterlab_gcedetails/src/components/error_page.tsx
@@ -17,14 +17,15 @@
 import * as csstips from 'csstips';
 import * as React from 'react';
 
-import { BASE_FONT, Message } from 'gcp_jupyterlab_shared';
+import { BASE_FONT, Message, LearnMoreLink } from 'gcp_jupyterlab_shared';
 import { stylesheet, classes } from 'typestyle';
-import { ConfigurationError, ErrorType } from './hardware_configuration_dialog';
+import { ConfigurationError, ErrorType } from './hardware_scaling_status';
 import { Instance } from '../service/notebooks_service';
 import { ActionBar } from './action_bar';
 import { getGpuTypeText, getMachineTypeText } from '../data';
 
 interface Props {
+  instanceDetails?: Instance;
   error: ConfigurationError;
   onDialogClose: () => void;
 }
@@ -83,8 +84,8 @@ function displayInstance(instance: Instance) {
 }
 
 export function ErrorPage(props: Props) {
-  const { onDialogClose, error } = props;
-  const { errorType, errorValue, instanceDetails } = error;
+  const { onDialogClose, error, instanceDetails } = props;
+  const { errorType, errorValue } = error;
 
   return (
     <div className={STYLES.container}>
@@ -97,13 +98,10 @@ export function ErrorPage(props: Props) {
       </div>
       {errorType === ErrorType.START && (
         <div className={STYLES.infoMessage}>
-          <Message
-            asError={true}
-            asActivity={false}
-            text={ERROR_MESSAGE}
-            link={LINK}
-            linkText={LINK_TEXT}
-          />
+          <Message asError={true} asActivity={false} text={ERROR_MESSAGE}>
+            {ERROR_MESSAGE}
+            <LearnMoreLink href={LINK} text={LINK_TEXT} />
+          </Message>
         </div>
       )}
       {errorType !== ErrorType.START && (

--- a/jupyterlab_gcedetails/src/components/error_page.tsx
+++ b/jupyterlab_gcedetails/src/components/error_page.tsx
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as csstips from 'csstips';
+import * as React from 'react';
+
+import { BASE_FONT, Message } from 'gcp_jupyterlab_shared';
+import { stylesheet, classes } from 'typestyle';
+import { ConfigurationError, ErrorType } from './hardware_configuration_dialog';
+import { Instance } from '../service/notebooks_service';
+import { ActionBar } from './action_bar';
+import { getGpuTypeText, getMachineTypeText } from '../data';
+
+interface Props {
+  error: ConfigurationError;
+  onDialogClose: () => void;
+}
+
+export const STYLES = stylesheet({
+  title: {
+    ...BASE_FONT,
+    fontWeight: 500,
+    fontSize: '15px',
+    marginBottom: '5px',
+    ...csstips.horizontal,
+    ...csstips.flex,
+  },
+  text: {
+    display: 'block',
+  },
+  textContainer: {
+    padding: '26px 16px 0px 16px',
+  },
+  container: {
+    width: '500px',
+  },
+  topPadding: {
+    paddingTop: '15px',
+  },
+  infoMessage: {
+    margin: '20px 16px 0px 16px',
+  },
+});
+
+const ERROR_MESSAGE = `You must manually start your instance from the Google Cloud Console to continue using this Notebook. `;
+const LINK = `https://console.cloud.google.com/ai-platform/notebooks/`;
+const LINK_TEXT = `View Cloud Console`;
+
+function displayInstance(instance: Instance) {
+  console.log('display instance');
+  const { machineType, acceleratorConfig } = instance;
+  const machineTypeText = getMachineTypeText(machineType.split('/').pop());
+
+  return (
+    <div>
+      <span className={classes(STYLES.title, STYLES.topPadding)}>
+        Your current configuration:
+      </span>
+      {machineTypeText && (
+        <div className={STYLES.text}>Machine type: {machineTypeText}</div>
+      )}
+      {acceleratorConfig && (
+        <div className={STYLES.text}>
+          {`GPUs: ${acceleratorConfig.coreCount} ${getGpuTypeText(
+            acceleratorConfig.type
+          )}`}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ErrorPage(props: Props) {
+  const { onDialogClose, error } = props;
+  const { errorType, errorValue, instanceDetails } = error;
+
+  return (
+    <div className={STYLES.container}>
+      <div className={STYLES.textContainer}>
+        <span
+          className={STYLES.title}
+        >{`Failed to ${errorType} Your Machine`}</span>
+        {errorValue}
+        {instanceDetails && displayInstance(instanceDetails)}
+      </div>
+      {errorType === ErrorType.START && (
+        <div className={STYLES.infoMessage}>
+          <Message
+            asError={true}
+            asActivity={false}
+            text={ERROR_MESSAGE}
+            link={LINK}
+            linkText={LINK_TEXT}
+          />
+        </div>
+      )}
+      {errorType !== ErrorType.START && (
+        <ActionBar primaryLabel="Close" onPrimaryClick={onDialogClose} />
+      )}
+    </div>
+  );
+}

--- a/jupyterlab_gcedetails/src/components/hardware_configuration_dialog.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_configuration_dialog.tsx
@@ -18,7 +18,7 @@ import { Dialog } from '@material-ui/core';
 import * as React from 'react';
 import { HardwareScalingForm } from './hardware_scaling_form';
 import { HardwareScalingStatus } from './hardware_scaling_status';
-import { NotebooksService, Instance } from '../service/notebooks_service';
+import { NotebooksService } from '../service/notebooks_service';
 import {
   HardwareConfiguration,
   Details,
@@ -27,27 +27,12 @@ import {
 import { ConfirmationPage } from './confirmation_page';
 import { ServerWrapper } from './server_wrapper';
 import { DetailsDialogBody } from './details_dialog_body';
-import { ErrorPage } from './error_page';
 
 enum View {
   DETAILS,
   FORM,
   CONFIRMATION,
   STATUS,
-  ERROR,
-}
-
-export enum ErrorType {
-  STOP = 'Stop',
-  RESHAPING = 'Reshape',
-  START = 'Start',
-  REFRESH = 'Refresh',
-}
-
-export interface ConfigurationError {
-  errorType: ErrorType;
-  errorValue: any;
-  instanceDetails?: Instance;
 }
 
 interface Props {
@@ -63,7 +48,6 @@ interface Props {
 interface State {
   view: View;
   hardwareConfiguration: HardwareConfiguration;
-  error: ConfigurationError;
 }
 
 export class HardwareConfigurationDialog extends React.Component<Props, State> {
@@ -72,7 +56,6 @@ export class HardwareConfigurationDialog extends React.Component<Props, State> {
     this.state = {
       view: View.DETAILS,
       hardwareConfiguration: null,
-      error: null,
     };
   }
 
@@ -80,20 +63,6 @@ export class HardwareConfigurationDialog extends React.Component<Props, State> {
     const { open } = this.props;
 
     return <Dialog open={open}>{this.getDisplay()}</Dialog>;
-  }
-
-  private onError(
-    errorValue,
-    errorType: ErrorType,
-    instanceDetails?: Instance
-  ) {
-    this.setState({
-      error: {
-        errorValue,
-        errorType,
-        instanceDetails,
-      },
-    });
   }
 
   private getDisplay() {
@@ -105,7 +74,7 @@ export class HardwareConfigurationDialog extends React.Component<Props, State> {
       detailsServer,
       receivedError,
     } = this.props;
-    const { view, hardwareConfiguration, error } = this.state;
+    const { view, hardwareConfiguration } = this.state;
 
     switch (view) {
       case View.DETAILS:
@@ -159,19 +128,8 @@ export class HardwareConfigurationDialog extends React.Component<Props, State> {
             notebookService={notebookService}
             onCompletion={onCompletion}
             detailsServer={detailsServer}
-            onError={(err, errorType, instanceDetails?) =>
-              this.onError(err, errorType, instanceDetails)
-            }
-            showErrorPage={() => {
-              this.setState({
-                view: View.ERROR,
-              });
-            }}
           />
         );
-
-      case View.ERROR:
-        return <ErrorPage onDialogClose={onClose} error={error} />;
     }
   }
 }

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_status.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_status.tsx
@@ -266,7 +266,7 @@ export class HardwareScalingStatus extends React.Component<Props, State> {
     const progressValue = (status / 6) * 100;
     const { flexContainer, heading, paragraph } = STYLES;
     const { onDialogClose } = this.props;
-    return status === 7 ? (
+    return status === Status['Error'] ? (
       <ErrorPage
         onDialogClose={onDialogClose}
         error={error}
@@ -276,7 +276,7 @@ export class HardwareScalingStatus extends React.Component<Props, State> {
       <div className={flexContainer}>
         <h3 className={heading}>{Status[status]}</h3>
         <p className={paragraph}>{statusInfo[status]}</p>
-        {status === 6 ? (
+        {status === Status['Complete'] ? (
           <Button
             variant="contained"
             color="primary"

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_status.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_status.tsx
@@ -51,7 +51,6 @@ enum Status {
   'Stopping Instance' = 1,
   'Reshaping Instance' = 2,
   'Starting Instance' = 3,
-  'Refreshing Session' = 4,
   'Complete' = 5,
   'Error' = 6,
 }
@@ -61,7 +60,6 @@ const statusInfo = [
   'Shutting down instance for reshaping.',
   'Reshaping instance to your configuration.',
   'Restarting your instance. Your newly configured machine will be ready very shortly!',
-  'Refreshing your JupyterLab session.',
   'Operation complete. Enjoy your newly configured instance! You may now close this dialog.',
   'An error has occured, please try again later. You may need to restart the instance manually.',
 ];
@@ -225,7 +223,7 @@ export class HardwareScalingStatus extends React.Component<Props, State> {
       <div className={flexContainer}>
         <h3 className={heading}>{Status[status]}</h3>
         <p className={paragraph}>{statusInfo[status]}</p>
-        {status === 5 || status === 6 ? (
+        {status === 4 || status === 5 ? (
           <Button
             variant="contained"
             color="primary"

--- a/jupyterlab_gcedetails/src/data.ts
+++ b/jupyterlab_gcedetails/src/data.ts
@@ -96,6 +96,10 @@ export const ACCELERATOR_TYPES: Option[] = [
   { value: 'NVIDIA_TESLA_V100', text: 'NVIDIA Tesla V100' },
 ];
 
+export function getGpuTypeText(value: string) {
+  return ACCELERATOR_TYPES.find(option => option.value === value).text;
+}
+
 /**
  * AI Platform Accelerator counts.
  * https://cloud.google.com/ai-platform/training/docs/using-gpus
@@ -376,6 +380,18 @@ export const MACHINE_TYPES: MachineTypeConfiguration[] = [
     ],
   },
 ];
+
+export function getMachineTypeText(value: string) {
+  const machineType = MACHINE_TYPES.find(machineType =>
+    value.startsWith(machineType.base.value as string)
+  );
+
+  return machineType
+    ? machineType.configurations.find(
+        configuration => configuration.value === value
+      ).text
+    : null;
+}
 
 /* Class names applied to the component. */
 export const STYLES = stylesheet({

--- a/jupyterlab_gcedetails/src/service/notebooks_service.spec.ts
+++ b/jupyterlab_gcedetails/src/service/notebooks_service.spec.ts
@@ -221,7 +221,7 @@ describe('NotebookInstanceServiceLayer', () => {
       try {
         await notebooksService.stop();
       } catch (err) {
-        expect(err).toEqual('400: Could not stop Notebook Instance');
+        expect(err).toEqual('Could not stop Notebook Instance');
       }
       stopTimers();
 
@@ -325,7 +325,7 @@ describe('NotebookInstanceServiceLayer', () => {
       try {
         await notebooksService.start();
       } catch (err) {
-        expect(err).toEqual('400: Could not start Notebook Instance');
+        expect(err).toEqual('Could not start Notebook Instance');
       }
       stopTimers();
 
@@ -437,9 +437,7 @@ describe('NotebookInstanceServiceLayer', () => {
       try {
         await notebooksService.setMachineType(machineType);
       } catch (err) {
-        expect(err).toEqual(
-          '400: Could not set Machine Type of Notebook Instance'
-        );
+        expect(err).toEqual('Could not set Machine Type of Notebook Instance');
       }
       stopTimers();
 
@@ -558,7 +556,7 @@ describe('NotebookInstanceServiceLayer', () => {
         await notebooksService.setAccelerator(type, coreCount);
       } catch (err) {
         expect(err).toEqual(
-          '400: Could not attach Accelerator to Notebook Instance'
+          'Could not attach Accelerator to Notebook Instance'
         );
       }
       stopTimers();

--- a/jupyterlab_gcedetails/src/service/notebooks_service.ts
+++ b/jupyterlab_gcedetails/src/service/notebooks_service.ts
@@ -23,7 +23,6 @@ import {
   PATCH,
   POST,
   ApiRequest,
-  // handleApiError,
 } from 'gcp_jupyterlab_shared';
 
 const POLL_INTERVAL = 5000;

--- a/jupyterlab_gcedetails/src/service/notebooks_service.ts
+++ b/jupyterlab_gcedetails/src/service/notebooks_service.ts
@@ -17,13 +17,13 @@
 /* eslint-disable @typescript-eslint/camelcase */
 
 import {
-  handleApiError,
   ClientTransportService,
   InstanceMetadata,
   getMetadata,
   PATCH,
   POST,
   ApiRequest,
+  // handleApiError,
 } from 'gcp_jupyterlab_shared';
 
 const POLL_INTERVAL = 5000;
@@ -52,16 +52,13 @@ type Operation = gapi.client.servicemanagement.Operation;
 
 export const NOTEBOOKS_API_PATH = 'https://notebooks.googleapis.com/v1beta1';
 
-const GOOGLE_API_UNAUTHENITCATED_CODE = 16;
-
-export function isUnauthorized(err: any) {
-  // Check for Google API Error structure and Unauthenticated error code
+export function handleError(err: any) {
+  // Check for Google API Error structure
   // https://cloud.google.com/apis/design/errors#error_codes
   if (err.result && err.result.error) {
-    return err.result.error.code === GOOGLE_API_UNAUTHENITCATED_CODE;
+    throw `${err.result.error.message}`;
   }
-
-  return false;
+  throw err;
 }
 
 /**
@@ -252,7 +249,7 @@ export class NotebooksService {
     try {
       const { zone } = await this._getMetadata();
       // extract the location from the zone resource name
-      const locationId = zone.split('/')[3];
+      const locationId = zone.split('/').pop();
       this.locationIdPromise = Promise.resolve(locationId);
       return this.locationIdPromise;
     } catch (err) {
@@ -298,7 +295,7 @@ export class NotebooksService {
       return finishedOperation.response as Instance;
     } catch (err) {
       console.error(errorMessage);
-      handleApiError(err);
+      handleError(err);
     }
   }
 

--- a/shared/gcp_jupyterlab_shared/__init__.py
+++ b/shared/gcp_jupyterlab_shared/__init__.py
@@ -15,7 +15,7 @@
 from notebook.utils import url_path_join
 
 # Needs to be set before handlers since they import VERSION
-VERSION = '1.0.5'
+VERSION = '1.0.6'
 
 from .handlers import MetadataHandler, ProxyHandler, ProjectHandler, RuntimeEnvHandler
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcp_jupyterlab_shared",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Shared libraries for JupyterLab extensions",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/shared/src/components/message.tsx
+++ b/shared/src/components/message.tsx
@@ -20,10 +20,13 @@ import { classes, stylesheet } from 'typestyle';
 import { css } from '../styles';
 import { Progress } from './progress';
 import { RedError, BlueInfo } from './status_icons';
+import { LearnMoreLink } from './learn_more_link';
 
 interface Props {
   asError?: boolean;
   asActivity?: boolean;
+  link?: string;
+  linkText?: string;
   text: string;
 }
 
@@ -63,7 +66,12 @@ export function Message(props: Props): JSX.Element {
       ) : (
         <BlueInfo />
       )}
-      <span className={localStyles.text}>{props.text}</span>
+      <span className={localStyles.text}>
+        {props.text}
+        {props.link && (
+          <LearnMoreLink href={props.link} text={props.linkText} />
+        )}
+      </span>
     </div>
   );
 }

--- a/shared/src/components/message.tsx
+++ b/shared/src/components/message.tsx
@@ -20,14 +20,12 @@ import { classes, stylesheet } from 'typestyle';
 import { css } from '../styles';
 import { Progress } from './progress';
 import { RedError, BlueInfo } from './status_icons';
-import { LearnMoreLink } from './learn_more_link';
 
 interface Props {
+  children?: React.ReactNode;
   asError?: boolean;
   asActivity?: boolean;
-  link?: string;
-  linkText?: string;
-  text: string;
+  text?: string;
 }
 
 const localStyles = stylesheet({
@@ -67,10 +65,7 @@ export function Message(props: Props): JSX.Element {
         <BlueInfo />
       )}
       <span className={localStyles.text}>
-        {props.text}
-        {props.link && (
-          <LearnMoreLink href={props.link} text={props.linkText} />
-        )}
+        {props.children ? props.children : props.text}
       </span>
     </div>
   );


### PR DESCRIPTION
Adds error handling for when Notebook API calls fail:
 - If  fails, the instance will be started and the user will be shown the error and the current state of their hardware configuration:
  - https://screencast.googleplex.com/cast/NjMzNzE5NDM3NTUxMjA2NHxiZjc3OGMwZC0wZg
 - If starting the machine fails, the user will be stuck on a dialog asking them to start their machine on the cloud console: 
  - https://screencast.googleplex.com/cast/NTEzMjgxNjg5MzM0NTc5MnxhNGRlMDBiOC1hYw

We can decide on the styling we want for the dialog contents and update it in a different PR