### PR TITLE
[HardwareConfiguration] Allow user to remove GPUs

### DIFF
--- a/jupyterlab_gcedetails/src/components/confirmation_page.tsx
+++ b/jupyterlab_gcedetails/src/components/confirmation_page.tsx
@@ -19,7 +19,11 @@ import * as React from 'react';
 
 import { BASE_FONT, Message } from 'gcp_jupyterlab_shared';
 import { stylesheet, classes } from 'typestyle';
-import { HardwareConfiguration, getGpuTypeText } from '../data';
+import {
+  HardwareConfiguration,
+  getGpuTypeText,
+  NO_ACCELERATOR_TYPE,
+} from '../data';
 import { HardwareConfigurationDescription } from './hardware_scaling_form';
 import { ActionBar } from './action_bar';
 
@@ -69,7 +73,7 @@ function displayConfiguration(
     <div>
       <span className={classes(STYLES.title, STYLES.topPadding)}>{title}</span>
       <div className={STYLES.text}>Machine type: {machineType.description}</div>
-      {attachGpu && (
+      {attachGpu && gpuType !== NO_ACCELERATOR_TYPE && (
         <div className={STYLES.text}>
           {`GPUs: ${gpuCount} ${getGpuTypeText(gpuType)}`}
         </div>

--- a/jupyterlab_gcedetails/src/data.ts
+++ b/jupyterlab_gcedetails/src/data.ts
@@ -87,7 +87,11 @@ export interface HardwareConfiguration {
 /**
  * AI Platform Accelerator types.
  * https://cloud.google.com/ai-platform/training/docs/using-gpus#compute-engine-machine-types-with-gpu
+ * https://cloud.google.com/ai-platform/notebooks/docs/reference/rest/v1beta1/projects.locations.instances#AcceleratorType
  */
+export const NO_ACCELERATOR_TYPE = 'ACCELERATOR_TYPE_UNSPECIFIED';
+export const NO_ACCELERATOR_COUNT = '0';
+
 export const ACCELERATOR_TYPES: Option[] = [
   { value: 'NVIDIA_TESLA_K80', text: 'NVIDIA Tesla K80' },
   { value: 'NVIDIA_TESLA_P4', text: 'NVIDIA Tesla P4' },
@@ -111,8 +115,6 @@ export const ACCELERATOR_COUNTS_1_2_4_8: Option[] = [
   { value: '8', text: '8' },
 ];
 
-export const NO_ACCELERATOR = '';
-
 /**
  * Convert nvidia-smi product_name type to match the AcceleratorType
  * enums that are used in the Notebooks API:
@@ -123,7 +125,7 @@ function nvidiaNameToEnum(name: string): string {
     accelerator.text.endsWith(name)
   );
 
-  return accelerator ? (accelerator.value as string) : NO_ACCELERATOR;
+  return accelerator ? (accelerator.value as string) : NO_ACCELERATOR_TYPE;
 }
 
 /**
@@ -161,7 +163,8 @@ export function getGpuCountOptionsList(
   accelerators: Accelerator[],
   acceleratorName: string
 ): Option[] {
-  if (acceleratorName === NO_ACCELERATOR) return ACCELERATOR_COUNTS_1_2_4_8;
+  if (acceleratorName === NO_ACCELERATOR_TYPE)
+    return ACCELERATOR_COUNTS_1_2_4_8;
 
   const accelerator = accelerators.find(
     accelerator => acceleratorNameToEnum(accelerator.name) === acceleratorName
@@ -198,7 +201,7 @@ export function detailsToHardwareConfiguration(
     machineType: instance.machineType,
     attachGpu: Boolean(gpu.name),
     gpuType: nvidiaNameToEnum(gpu.name),
-    gpuCount: gpu.name ? gpu.count : NO_ACCELERATOR,
+    gpuCount: gpu.name ? gpu.count : NO_ACCELERATOR_COUNT,
   };
 }
 


### PR DESCRIPTION
Adding functionality to allow a user to remove GPUs. If the configuration originally had GPUs attached and he user unchecks the attachGPU checkbox a request will be made to the setAccelerator Notebooks API to set the accelerator to ACCELERATOR_UNSPECIFIED with count 0.