### PR TITLE
[HardwareConfiguration] Disable submit reshaping if configuration is same

### DIFF
--- a/jupyterlab_gcedetails/src/components/action_bar.tsx
+++ b/jupyterlab_gcedetails/src/components/action_bar.tsx
@@ -8,6 +8,8 @@ interface Props {
   secondaryLabel?: string;
   onPrimaryClick: () => void;
   onSecondaryClick?: () => void;
+  primaryButtonProps?: React.ButtonHTMLAttributes<HTMLButtonElement>;
+  secondaryButtonProps?: React.ButtonHTMLAttributes<HTMLButtonElement>;
 }
 
 const STYLES = stylesheet({
@@ -26,6 +28,15 @@ const STYLES = stylesheet({
   primaryButton: {
     backgroundColor: COLORS.blue,
     color: COLORS.white,
+    $nest: {
+      '&:disabled': {
+        backgroundColor: '#bfbfbf',
+      },
+      '&:hover': {
+        cursor: 'pointer',
+      },
+      '&:disabled:hover': { cursor: 'default' },
+    },
   },
 });
 
@@ -38,6 +49,7 @@ export function ActionBar(props: Props) {
           type="button"
           className={css.button}
           onClick={props.onSecondaryClick}
+          {...props.secondaryButtonProps}
         >
           {props.secondaryLabel}
         </button>
@@ -46,6 +58,7 @@ export function ActionBar(props: Props) {
         type="button"
         className={classes(css.button, STYLES.primaryButton)}
         onClick={props.onPrimaryClick}
+        {...props.primaryButtonProps}
       >
         {props.primaryLabel}
       </button>

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
@@ -40,6 +40,7 @@ import {
   detailsToHardwareConfiguration,
   NO_ACCELERATOR_TYPE,
   NO_ACCELERATOR_COUNT,
+  isEqualHardwareConfiguration,
 } from '../data';
 import { ActionBar } from './action_bar';
 
@@ -159,19 +160,16 @@ export class HardwareScalingForm extends React.Component<Props, State> {
   }
 
   private onAttachGpuChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const { gpuType, gpuCount } = this.state.configuration;
     this.setState({
       configuration: {
         ...this.state.configuration,
         attachGpu: event.target.checked,
-        gpuType:
-          gpuType === NO_ACCELERATOR_TYPE
-            ? (ACCELERATOR_TYPES[0].value as string)
-            : gpuType,
-        gpuCount:
-          gpuCount === NO_ACCELERATOR_COUNT
-            ? (ACCELERATOR_COUNTS_1_2_4_8[0].value as string)
-            : gpuCount,
+        gpuType: event.target.checked
+          ? (this.gpuTypeOptions[0].value as string)
+          : NO_ACCELERATOR_TYPE,
+        gpuCount: event.target.checked
+          ? (this.state.gpuCountOptions[0].value as string)
+          : NO_ACCELERATOR_COUNT,
       },
     });
   }
@@ -205,9 +203,6 @@ export class HardwareScalingForm extends React.Component<Props, State> {
   private submitForm() {
     const configuration = { ...this.state.configuration };
     if (!configuration.attachGpu) {
-      configuration.gpuType = NO_ACCELERATOR_TYPE;
-      configuration.gpuCount = NO_ACCELERATOR_COUNT;
-
       /*
        * If machine originally had a GPU we want to explicilty attach an
        * accelerator of type NO_ACCELERATOR_TYPE through the Notebooks API to remove it
@@ -288,6 +283,12 @@ export class HardwareScalingForm extends React.Component<Props, State> {
         <ActionBar
           primaryLabel="Next"
           onPrimaryClick={() => this.submitForm()}
+          primaryButtonProps={{
+            disabled: isEqualHardwareConfiguration(
+              this.oldConfiguration,
+              configuration
+            ),
+          }}
           secondaryLabel="Cancel"
           onSecondaryClick={onDialogClose}
         />

--- a/jupyterlab_gcedetails/src/data.ts
+++ b/jupyterlab_gcedetails/src/data.ts
@@ -121,10 +121,11 @@ export const ACCELERATOR_COUNTS_1_2_4_8: Option[] = [
  * https://cloud.google.com/ai-platform/notebooks/docs/reference/rest/v1beta1/projects.locations.instances#AcceleratorType
  */
 function nvidiaNameToEnum(name: string): string {
+  if (name === '') return NO_ACCELERATOR_TYPE;
+
   const accelerator = ACCELERATOR_TYPES.find(accelerator =>
     accelerator.text.endsWith(name)
   );
-
   return accelerator ? (accelerator.value as string) : NO_ACCELERATOR_TYPE;
 }
 
@@ -203,6 +204,19 @@ export function detailsToHardwareConfiguration(
     gpuType: nvidiaNameToEnum(gpu.name),
     gpuCount: gpu.name ? gpu.count : NO_ACCELERATOR_COUNT,
   };
+}
+
+export function isEqualHardwareConfiguration(
+  a: HardwareConfiguration,
+  b: HardwareConfiguration
+) {
+  return (
+    a.machineType.name === b.machineType.name &&
+    a.machineType.description === b.machineType.description &&
+    a.attachGpu === b.attachGpu &&
+    a.gpuType === b.gpuType &&
+    a.gpuCount === b.gpuCount
+  );
 }
 
 interface AttributeMapper {


### PR DESCRIPTION
Disables the submit button on the hardware scaling form if the user hasn't made any changes to their current configuration. Also changes the gpuType and gpuCount to always default to the first option when the attachGpu checkbox is checked.