### PR TITLE
[Comments] add new comment with right-click file editor command

### DIFF
--- a/jupyterlab_comments/src/components/code_review.tsx
+++ b/jupyterlab_comments/src/components/code_review.tsx
@@ -48,15 +48,11 @@ const style = {
 
 export class CodeReview extends React.Component<Props> {
   render() {
-    const comments = this.props.commentsList.map(comment => (
-      <>
-        <Comment
-          reviewComment={comment}
-          file={this.props.file}
-          key={comment.timestamp}
-        />
+    const comments = this.props.commentsList.map((comment, index) => (
+      <div key={index}>
+        <Comment reviewComment={comment} file={this.props.file} />
         <Divider />
-      </>
+      </div>
     ));
     const reviewTimeStamp = timeAgo(
       new Date().getTime(),

--- a/jupyterlab_comments/src/components/comment.tsx
+++ b/jupyterlab_comments/src/components/comment.tsx
@@ -178,7 +178,7 @@ export class Comment extends React.Component<Props, State> {
         <div style={style.threadIndent} className="threadList">
           {this.state.expandThread && data.children && (
             <List>
-              {data.children.map(reply => {
+              {data.children.map((reply, index) => {
                 if (this.props.detachedComment) {
                   const detached = createDetachedCommentFromJSON(
                     reply,
@@ -188,6 +188,7 @@ export class Comment extends React.Component<Props, State> {
                     <Comment
                       detachedComment={detached}
                       file={this.props.file}
+                      key={index}
                     />
                   );
                 } else {
@@ -198,7 +199,11 @@ export class Comment extends React.Component<Props, State> {
                     data.filePath
                   );
                   return (
-                    <Comment reviewComment={review} file={this.props.file} />
+                    <Comment
+                      reviewComment={review}
+                      file={this.props.file}
+                      key={index}
+                    />
                   );
                 }
               })}

--- a/jupyterlab_comments/src/components/comment_context.tsx
+++ b/jupyterlab_comments/src/components/comment_context.tsx
@@ -44,8 +44,8 @@ export class CommentContext extends React.Component<Props> {
   render() {
     const context = this.props.file.getContext(this.props.range);
     if (context) {
-      const lines = context.map(line => (
-        <div>
+      const lines = context.map((line, index) => (
+        <div key={index}>
           <p style={styles.lineNumber}> {line[0]} </p>
           <code style={styles.lineText}> {line[1]} </code>
         </div>

--- a/jupyterlab_comments/src/components/comments_widget.tsx
+++ b/jupyterlab_comments/src/components/comments_widget.tsx
@@ -44,7 +44,7 @@ import { IDocumentManager } from '@jupyterlab/docmanager';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { Comment } from '../components/comment';
 import { NewCommentThread } from '../components/start_thread';
-import { getServerRoot } from '../service/jupyterConfig';
+import { getServerRoot, Context } from '../service/jupyterConfig';
 import { CodeReview } from '../components/code_review';
 import { RegularFile, NotebookFile } from '../service/file';
 
@@ -61,10 +61,10 @@ interface State {
   errorMessage: string;
 }
 
-export interface Context {
-  labShell: ILabShell;
-  docManager: IDocumentManager;
-}
+// export interface Context {
+//   labShell: ILabShell;
+//   docManager: IDocumentManager;
+// }
 
 const localStyles = stylesheet({
   root: {
@@ -268,6 +268,7 @@ export class CommentsComponent extends React.Component<Props, State> {
                 const comment = createDetachedCommentFromJSON(obj, filePath);
                 comments.push(comment);
               });
+              comments.reverse();
             }
           }
           this.setState({
@@ -312,6 +313,7 @@ export class CommentsComponent extends React.Component<Props, State> {
                     );
                     comments.push(comment);
                   });
+                  comments.reverse();
                   reviews.push([request, comments]);
                 }
               });

--- a/jupyterlab_comments/src/components/comments_widget.tsx
+++ b/jupyterlab_comments/src/components/comments_widget.tsx
@@ -147,18 +147,20 @@ export class CommentsComponent extends React.Component<Props, State> {
     } else {
       file = new RegularFile(currWidget as IDocumentWidget);
     }
-    const detachedCommentsList = this.state.detachedComments.map(comment => (
-      <>
-        <Comment detachedComment={comment} file={file} />
-        <Divider />
-      </>
-    ));
+    const detachedCommentsList = this.state.detachedComments.map(
+      (comment, index) => (
+        <div key={index}>
+          <Comment detachedComment={comment} file={file} />
+          <Divider />
+        </div>
+      )
+    );
     const numDetachedComments = this.state.detachedComments.length;
     const detachedLabel: string =
       'Detached (' + numDetachedComments.toString() + ')';
     const reviewCommentsList = this.state.reviewComments.map(
-      reviewCommentsArr => (
-        <>
+      (reviewCommentsArr, index) => (
+        <div key={index}>
           <CodeReview
             reviewRequest={reviewCommentsArr[0]}
             commentsList={reviewCommentsArr[1]}
@@ -170,7 +172,7 @@ export class CommentsComponent extends React.Component<Props, State> {
             commentType="review"
             reviewHash={reviewCommentsArr[0].reviewHash}
           />
-        </>
+        </div>
       )
     );
     return (

--- a/jupyterlab_comments/src/components/comments_widget.tsx
+++ b/jupyterlab_comments/src/components/comments_widget.tsx
@@ -39,8 +39,6 @@ import {
 } from '@material-ui/core';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import CommentIcon from '@material-ui/icons/Comment';
-import { ILabShell } from '@jupyterlab/application';
-import { IDocumentManager } from '@jupyterlab/docmanager';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { Comment } from '../components/comment';
 import { NewCommentThread } from '../components/start_thread';
@@ -60,11 +58,6 @@ interface State {
   activeTab: number;
   errorMessage: string;
 }
-
-// export interface Context {
-//   labShell: ILabShell;
-//   docManager: IDocumentManager;
-// }
 
 const localStyles = stylesheet({
   root: {

--- a/jupyterlab_comments/src/components/new_comment_dialog.tsx
+++ b/jupyterlab_comments/src/components/new_comment_dialog.tsx
@@ -1,11 +1,18 @@
 import React, { useState } from 'react';
-import { Button, TextField, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
+import {
+  Button,
+  TextField,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@material-ui/core';
 import { ReactWidget } from '@jupyterlab/apputils';
-import { NewCommentThread } from './start_thread';
-import { getServerRoot } from '../service/jupyterConfig';
+import { getServerRoot, Context } from '../service/jupyterConfig';
 
 function NewCommentDialog(props) {
-  const [open, setOpen] = React.useState(true);
+  const [open, setOpen] = useState(true);
   const [comment, setComment] = useState('');
 
   const handleCloseCancel = () => {
@@ -14,16 +21,19 @@ function NewCommentDialog(props) {
 
   const handleCloseSend = () => {
     setOpen(false);
-  }
+    console.log(comment);
+  };
 
   return (
     <div>
-      <Dialog open={open} onClose={handleCloseCancel} aria-labelledby="form-dialog-title">
+      <Dialog
+        open={open}
+        onClose={handleCloseCancel}
+        aria-labelledby="form-dialog-title"
+      >
         <DialogTitle id="form-dialog-title">Subscribe</DialogTitle>
         <DialogContent>
-          <DialogContentText>
-            Start a new comment thread
-          </DialogContentText>
+          <DialogContentText>Start a new comment thread</DialogContentText>
           <TextField
             autoFocus
             margin="dense"
@@ -33,7 +43,6 @@ function NewCommentDialog(props) {
             onChange={e => setComment(e.target.value)}
             fullWidth
           />
-          <NewCommentThread {...this.props}/>
         </DialogContent>
         <DialogActions>
           <Button onClick={handleCloseCancel} color="primary">
@@ -57,16 +66,15 @@ interface Props {
 
 class DialogComponent extends React.Component<Props> {
   render() {
-    return <NewCommentDialog {...this.props}/>;
+    return <NewCommentDialog {...this.props} />;
   }
 }
 
 export class NewCommentDialogWidget extends ReactWidget {
+  context: Context;
+  selection: object;
 
-  context : object;
-  selection : object;
-
-  constructor(selection : object, context: object) {
+  constructor(selection: object, context: Context) {
     super();
     this.selection = selection;
     this.context = context;
@@ -75,6 +83,13 @@ export class NewCommentDialogWidget extends ReactWidget {
     const serverRoot = getServerRoot();
     const currWidget = this.context.labShell.currentWidget;
     const filePath = this.context.docManager.contextForWidget(currWidget).path;
-    return (<DialogComponent selection={this.selection} serverRoot={serverRoot} commentType="detached" currFilePath={filePath}/>);
+    return (
+      <DialogComponent
+        selection={this.selection}
+        serverRoot={serverRoot}
+        commentType="detached"
+        currFilePath={filePath}
+      />
+    );
   }
 }

--- a/jupyterlab_comments/src/components/new_comment_dialog.tsx
+++ b/jupyterlab_comments/src/components/new_comment_dialog.tsx
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import React, { useState } from 'react';
 import {
   Button,
@@ -5,11 +20,17 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
-  DialogContentText,
   DialogTitle,
 } from '@material-ui/core';
 import { ReactWidget } from '@jupyterlab/apputils';
 import { getServerRoot, Context } from '../service/jupyterConfig';
+import { newDetachedCommentThread } from '../service/add_comment';
+
+const style = {
+  textField: {
+    width: 400,
+  },
+};
 
 function NewCommentDialog(props) {
   const [open, setOpen] = useState(true);
@@ -21,7 +42,13 @@ function NewCommentDialog(props) {
 
   const handleCloseSend = () => {
     setOpen(false);
-    console.log(comment);
+    const lineNumber = props.selection.start.line;
+    newDetachedCommentThread(
+      props.currFilePath,
+      props.serverRoot,
+      comment,
+      lineNumber
+    );
   };
 
   return (
@@ -31,16 +58,19 @@ function NewCommentDialog(props) {
         onClose={handleCloseCancel}
         aria-labelledby="form-dialog-title"
       >
-        <DialogTitle id="form-dialog-title">Subscribe</DialogTitle>
+        <DialogTitle id="form-dialog-title">Add a comment</DialogTitle>
         <DialogContent>
-          <DialogContentText>Start a new comment thread</DialogContentText>
           <TextField
             autoFocus
+            multiline
             margin="dense"
-            id="name"
-            label="Start typing..."
+            rows={3}
             value={comment}
+            variant="outlined"
+            size="medium"
+            label="Start a new comment thread"
             onChange={e => setComment(e.target.value)}
+            style={style.textField}
             fullWidth
           />
         </DialogContent>

--- a/jupyterlab_comments/src/components/new_comment_dialog.tsx
+++ b/jupyterlab_comments/src/components/new_comment_dialog.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { Button, TextField, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
+import { ReactWidget } from '@jupyterlab/apputils';
+import { NewCommentThread } from './start_thread';
+import { getServerRoot } from '../service/jupyterConfig';
+
+function NewCommentDialog(props) {
+  const [open, setOpen] = React.useState(true);
+  const [comment, setComment] = useState('');
+
+  const handleCloseCancel = () => {
+    setOpen(false);
+  };
+
+  const handleCloseSend = () => {
+    setOpen(false);
+  }
+
+  return (
+    <div>
+      <Dialog open={open} onClose={handleCloseCancel} aria-labelledby="form-dialog-title">
+        <DialogTitle id="form-dialog-title">Subscribe</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Start a new comment thread
+          </DialogContentText>
+          <TextField
+            autoFocus
+            margin="dense"
+            id="name"
+            label="Start typing..."
+            value={comment}
+            onChange={e => setComment(e.target.value)}
+            fullWidth
+          />
+          <NewCommentThread {...this.props}/>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseCancel} color="primary">
+            Cancel
+          </Button>
+          <Button onClick={handleCloseSend} color="primary">
+            Send
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}
+
+interface Props {
+  serverRoot: string;
+  currFilePath: string;
+  commentType: 'detached' | 'review';
+  selection: object;
+}
+
+class DialogComponent extends React.Component<Props> {
+  render() {
+    return <NewCommentDialog {...this.props}/>;
+  }
+}
+
+export class NewCommentDialogWidget extends ReactWidget {
+
+  context : object;
+  selection : object;
+
+  constructor(selection : object, context: object) {
+    super();
+    this.selection = selection;
+    this.context = context;
+  }
+  render() {
+    const serverRoot = getServerRoot();
+    const currWidget = this.context.labShell.currentWidget;
+    const filePath = this.context.docManager.contextForWidget(currWidget).path;
+    return (<DialogComponent selection={this.selection} serverRoot={serverRoot} commentType="detached" currFilePath={filePath}/>);
+  }
+}

--- a/jupyterlab_comments/src/index.ts
+++ b/jupyterlab_comments/src/index.ts
@@ -79,14 +79,11 @@ function activate(
       if (!widget) {
         return;
       }
-      const editor = file.editor;
-      const selectionObj = file.editor.getSelection();
-      console.log(selectionObj);
-      console.log(editor);
+      const selectionObj = file.editor.getSelection(); //contains start/end line and column attributes
       const dialogWidget = new NewCommentDialogWidget(selectionObj, context);
       dialogWidget.id = 'new_comment';
 
-      app.shell.add(dialogWidget, 'bottom');
+      app.shell.add(dialogWidget, 'bottom'); //attach widget to UI so dialog can open
       app.shell.activateById(dialogWidget.id);
     },
     label: 'New comment',

--- a/jupyterlab_comments/src/index.ts
+++ b/jupyterlab_comments/src/index.ts
@@ -24,7 +24,14 @@ import { IDocumentManager } from '@jupyterlab/docmanager';
 
 import { MainAreaWidget, ICommandPalette } from '@jupyterlab/apputils';
 
+import { FileEditor } from '@jupyterlab/fileeditor';
+
+import { IDocumentWidget } from '@jupyterlab/docregistry';
+
 import { CommentsWidget } from './components/comments_widget';
+
+import { NewCommentDialogWidget } from './components/new_comment_dialog';
+
 
 function activate(
   app: JupyterFrontEnd,
@@ -37,16 +44,17 @@ function activate(
   let widget: MainAreaWidget<CommentsWidget>;
   let content: CommentsWidget;
 
+  const context = {
+    labShell: labShell,
+    docManager: docManager,
+  };
+
   // Add an application command
   const command = 'comments:open';
   app.commands.addCommand(command, {
     label: 'Notebook comments in git',
     execute: () => {
       if (!widget || widget.isDisposed) {
-        const context = {
-          labShell: labShell,
-          docManager: docManager,
-        };
         content = new CommentsWidget(context);
         widget = new MainAreaWidget<CommentsWidget>({ content });
         widget.id = 'jupyterlab_comments';
@@ -60,9 +68,36 @@ function activate(
       app.shell.activateById(widget.id);
     },
   });
-
   // Add the command to the palette.
   palette.addItem({ command, category: 'Collaboration' });
+
+  //Command for adding new comment to currently selected text
+  const addNewComment = 'comments:add';
+  app.commands.addCommand(addNewComment, {
+    execute: () => {
+      const file = ((labShell.currentWidget as IDocumentWidget).content as FileEditor);
+      if (!widget) {
+        return;
+      }
+      const editor = file.editor;
+      const selectionObj = file.editor.getSelection();
+      console.log(selectionObj);
+      console.log(editor);
+      const dialogWidget = new NewCommentDialogWidget(selectionObj, context);
+      dialogWidget.id = 'new_comment';
+
+      // app.shell.add(dialogWidget, 'left');
+      app.shell.activateById(dialogWidget.id);
+
+      },
+    label: 'New comment',
+  });
+  //Add command to file editor's right click context menu
+  app.contextMenu.addItem({
+      command: addNewComment,
+      selector: '.jp-FileEditor',
+      rank: 1
+  });
 }
 
 /**

--- a/jupyterlab_comments/src/index.ts
+++ b/jupyterlab_comments/src/index.ts
@@ -32,7 +32,6 @@ import { CommentsWidget } from './components/comments_widget';
 
 import { NewCommentDialogWidget } from './components/new_comment_dialog';
 
-
 function activate(
   app: JupyterFrontEnd,
   labShell: ILabShell,
@@ -75,7 +74,8 @@ function activate(
   const addNewComment = 'comments:add';
   app.commands.addCommand(addNewComment, {
     execute: () => {
-      const file = ((labShell.currentWidget as IDocumentWidget).content as FileEditor);
+      const file = (labShell.currentWidget as IDocumentWidget)
+        .content as FileEditor;
       if (!widget) {
         return;
       }
@@ -86,17 +86,16 @@ function activate(
       const dialogWidget = new NewCommentDialogWidget(selectionObj, context);
       dialogWidget.id = 'new_comment';
 
-      // app.shell.add(dialogWidget, 'left');
+      app.shell.add(dialogWidget, 'bottom');
       app.shell.activateById(dialogWidget.id);
-
-      },
+    },
     label: 'New comment',
   });
   //Add command to file editor's right click context menu
   app.contextMenu.addItem({
-      command: addNewComment,
-      selector: '.jp-FileEditor',
-      rank: 1
+    command: addNewComment,
+    selector: '.jp-FileEditor',
+    rank: 1,
   });
 }
 

--- a/jupyterlab_comments/src/index.ts
+++ b/jupyterlab_comments/src/index.ts
@@ -70,7 +70,10 @@ function activate(
   // Add the command to the palette.
   palette.addItem({ command, category: 'Collaboration' });
 
-  //Command for adding new comment to currently selected text
+  /*
+  Command for adding new comment to currently selected line in the file
+  This command only support non-Notebook files
+  */
   const addNewComment = 'comments:add';
   app.commands.addCommand(addNewComment, {
     execute: () => {
@@ -79,11 +82,11 @@ function activate(
       if (!widget) {
         return;
       }
-      const selectionObj = file.editor.getSelection(); //contains start/end line and column attributes
+      const selectionObj = file.editor.getSelection(); //contains start and end line and column attributes
       const dialogWidget = new NewCommentDialogWidget(selectionObj, context);
       dialogWidget.id = 'new_comment';
 
-      app.shell.add(dialogWidget, 'bottom'); //attach widget to UI so dialog can open
+      app.shell.add(dialogWidget, 'bottom'); //attach widget to UI to display dialog
       app.shell.activateById(dialogWidget.id);
     },
     label: 'New comment',

--- a/jupyterlab_comments/src/service/file.ts
+++ b/jupyterlab_comments/src/service/file.ts
@@ -55,12 +55,11 @@ export class RegularFile {
   codeMirror: CodeMirror;
   codeMirrorEditor: CodeMirrorEditor;
 
-
   constructor(widget: IDocumentWidget) {
     this.codeMirror = ((widget.content as FileEditor)
       .editor as CodeMirrorEditor).editor;
-    this.codeMirrorEditor = ((widget.content as FileEditor)
-      .editor as CodeMirrorEditor);
+    this.codeMirrorEditor = (widget.content as FileEditor)
+      .editor as CodeMirrorEditor;
     // let selection = this.codeMirrorEditor.getSelection();
     // let context = this.codeMirrorEditor.doc.getSelection(); //text of the selection
     // let startLine = selection.start.line;

--- a/jupyterlab_comments/src/service/file.ts
+++ b/jupyterlab_comments/src/service/file.ts
@@ -60,12 +60,6 @@ export class RegularFile {
       .editor as CodeMirrorEditor).editor;
     this.codeMirrorEditor = (widget.content as FileEditor)
       .editor as CodeMirrorEditor;
-    // let selection = this.codeMirrorEditor.getSelection();
-    // let context = this.codeMirrorEditor.doc.getSelection(); //text of the selection
-    // let startLine = selection.start.line;
-    // let endLine = selection.end.line;
-    // let startColumn = selection.start.column;
-    // let endColumn = selection.end.column;
   }
   /*
     Return an array of lines from the file that correspond to the given range object

--- a/jupyterlab_comments/src/service/file.ts
+++ b/jupyterlab_comments/src/service/file.ts
@@ -52,11 +52,21 @@ export class NotebookFile {
 }
 
 export class RegularFile {
-  editor: CodeMirror;
+  codeMirror: CodeMirror;
+  codeMirrorEditor: CodeMirrorEditor;
+
 
   constructor(widget: IDocumentWidget) {
-    this.editor = ((widget.content as FileEditor)
+    this.codeMirror = ((widget.content as FileEditor)
       .editor as CodeMirrorEditor).editor;
+    this.codeMirrorEditor = ((widget.content as FileEditor)
+      .editor as CodeMirrorEditor);
+    // let selection = this.codeMirrorEditor.getSelection();
+    // let context = this.codeMirrorEditor.doc.getSelection(); //text of the selection
+    // let startLine = selection.start.line;
+    // let endLine = selection.end.line;
+    // let startColumn = selection.start.column;
+    // let endColumn = selection.end.column;
   }
   /*
     Return an array of lines from the file that correspond to the given range object
@@ -74,7 +84,7 @@ export class RegularFile {
     }
     if (!range.endLine) {
       //Context is a single line, or part of a single line
-      const untrimmedLine: string = this.editor.getLine(range.startLine);
+      const untrimmedLine: string = this.codeMirror.getLine(range.startLine);
       //if untrimmedLine is undefined, the comment was left on a line in the file that no longer exists, so return null
       if (untrimmedLine) {
         const leftIndex = range.startColumn ? range.startColumn : 0;
@@ -97,7 +107,7 @@ export class RegularFile {
       //when range has both startLine and endLine attributes, take at most 3 lines of the file to display
       const endLine = Math.max(range.endLine, range.startLine + 3);
       for (let i = range.startLine; i < endLine; i++) {
-        contextInFile.push([i, this.editor.getLine(i)]);
+        contextInFile.push([i, this.codeMirror.getLine(i)]);
       }
       return contextInFile;
     }

--- a/jupyterlab_comments/src/service/jupyterConfig.ts
+++ b/jupyterlab_comments/src/service/jupyterConfig.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  **/
 import { PageConfig } from '@jupyterlab/coreutils';
+import { ILabShell } from '@jupyterlab/application';
+import { IDocumentManager } from '@jupyterlab/docmanager';
 
 export function getServerRoot() {
   return PageConfig.getOption('serverRoot');
+}
+
+export interface Context {
+    labShell: ILabShell;
+    docManager: IDocumentManager;
 }

--- a/jupyterlab_comments/src/service/jupyterConfig.ts
+++ b/jupyterlab_comments/src/service/jupyterConfig.ts
@@ -22,6 +22,6 @@ export function getServerRoot() {
 }
 
 export interface Context {
-    labShell: ILabShell;
-    docManager: IDocumentManager;
+  labShell: ILabShell;
+  docManager: IDocumentManager;
 }


### PR DESCRIPTION
- Add new command to FIleEditor's right click context menu that lets user add a new detached comment at the line number they have clicked on/highlighted
- Create new comment dialog widget that command uses

Also:
- Move Context interface containing labShell and docManager to jupyterConfig file
- Add missing unique keys for list item components