### PR TITLE
[BigQuery] Add correct icon to tabs

### DIFF
--- a/jupyterlab_bigquery/src/components/details_panel/dataset_details_widget.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/dataset_details_widget.tsx
@@ -14,7 +14,7 @@ export class DatasetDetailsWidget extends ReactWidget {
     private readonly name: string
   ) {
     super();
-    this.title.iconClass = 'jp-Icon jp-Icon-20 jp-BigQueryIcon';
+    this.title.iconClass = 'jp-Icon jp-Icon-20 jp-DatasetIcon';
     this.title.caption = `Dataset Details for ${this.dataset_id}`;
     this.title.label = this.name;
     this.title.closable = true;

--- a/jupyterlab_bigquery/src/components/details_panel/model_details_widget.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/model_details_widget.tsx
@@ -14,7 +14,7 @@ export class ModelDetailsWidget extends ReactWidget {
     private readonly name: string
   ) {
     super();
-    this.title.iconClass = 'jp-Icon jp-Icon-20 jp-BigQueryIcon';
+    this.title.iconClass = 'jp-Icon jp-Icon-20 jp-ModelIcon';
     this.title.caption = `Model Details for ${this.model_id}`;
     this.title.label = this.name;
     this.title.closable = true;

--- a/jupyterlab_bigquery/src/components/details_panel/table_details_widget.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_widget.tsx
@@ -11,10 +11,13 @@ export class TableDetailsWidget extends ReactWidget {
   constructor(
     private readonly service: TableDetailsService,
     private readonly table_id: string,
-    private readonly name: string
+    private readonly name: string,
+    private readonly partitioned: boolean
   ) {
     super();
-    this.title.iconClass = 'jp-Icon jp-Icon-20 jp-BigQueryIcon';
+    this.title.iconClass = this.partitioned
+      ? 'jp-Icon jp-Icon-20 jp-PartitionedTableIcon'
+      : 'jp-Icon jp-Icon-20 jp-TableIcon';
     this.title.caption = `Table Details for ${this.table_id}`;
     this.title.label = this.name;
     this.title.closable = true;

--- a/jupyterlab_bigquery/src/components/details_panel/view_details_widget.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/view_details_widget.tsx
@@ -14,7 +14,7 @@ export class ViewDetailsWidget extends ReactWidget {
     private readonly name: string
   ) {
     super();
-    this.title.iconClass = 'jp-Icon jp-Icon-20 jp-BigQueryIcon';
+    this.title.iconClass = 'jp-Icon jp-Icon-20 jp-ViewIcon';
     this.title.caption = `View Details for ${this.view_id}`;
     this.title.label = this.name;
     this.title.closable = true;

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
@@ -220,7 +220,7 @@ export class TableResource extends Resource<TableProps> {
     }
   };
 
-  openTableDetails = (event, table) => {
+  openTableDetails = (event, table: Table) => {
     event.stopPropagation();
     const service = new TableDetailsService();
     const widgetType = TableDetailsWidget;
@@ -229,7 +229,8 @@ export class TableResource extends Resource<TableProps> {
       widgetType,
       service,
       table.id,
-      table.name
+      table.name,
+      table.partitioned
     );
   };
 

--- a/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab_widget.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab_widget.tsx
@@ -20,6 +20,7 @@ export class QueryEditorTabWidget extends ReduxReactWidget {
   ) {
     super();
     this.title.label = `Query Editor ${this.editorNumber}`;
+    this.title.iconClass = 'jp-Icon jp-Icon-20 jp-BigQueryIcon';
     this.title.closable = true;
   }
 

--- a/jupyterlab_bigquery/src/components/query_history/query_history_widget.tsx
+++ b/jupyterlab_bigquery/src/components/query_history/query_history_widget.tsx
@@ -17,6 +17,7 @@ export class QueryHistoryWidget extends ReduxReactWidget {
   constructor(private readonly service: QueryHistoryService) {
     super();
     this.title.label = 'Query History';
+    this.title.iconClass = 'jp-Icon jp-Icon-20 jp-BigQueryIcon';
     this.title.closable = true;
   }
 


### PR DESCRIPTION
Replaces generic BigQuery icon with specific icons for respective widget types (dataset, view, partitioned table, table, etc)

![icons](https://user-images.githubusercontent.com/48393093/90665371-ee66dd80-e219-11ea-9345-50ad8855dce4.png)
