### PR TITLE
[BigQuery] Paginated UI for query history

### DIFF
--- a/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
+++ b/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Paper, Collapse, LinearProgress, Icon } from '@material-ui/core';
+import {
+  Paper,
+  Collapse,
+  LinearProgress,
+  Icon,
+  TablePagination,
+} from '@material-ui/core';
 import { CheckCircle, Error } from '@material-ui/icons';
 import { stylesheet } from 'typestyle';
 import { DateTime } from 'luxon';
@@ -18,16 +24,21 @@ import { QueryEditorTabWidget } from '../query_editor/query_editor_tab/query_edi
 import { WidgetManager } from '../../utils/widgetManager/widget_manager';
 import { generateQueryId } from '../../reducers/queryEditorTabSlice';
 import { formatTime, formatDate, formatBytes } from '../../utils/formatters';
+import { TablePaginationActions } from '../shared/bq_table';
 import { BASE_FONT } from 'gcp_jupyterlab_shared';
 
 const localStyles = stylesheet({
   queryHistoryRoot: {
     height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
     ...BASE_FONT,
   },
   body: {
-    height: '100%',
+    flex: 1,
+    minHeight: 0,
     overflowY: 'auto',
+    overflowX: 'hidden',
     backgroundColor: '#FAFAFA',
   },
   query: {
@@ -108,6 +119,15 @@ const localStyles = stylesheet({
     justifyContent: 'space-between',
     marginBottom: '14px',
   },
+  pagination: {
+    backgroundColor: 'white',
+    fontSize: '13px',
+    borderTop: 'var(--jp-border-width) solid var(--jp-border-color2)',
+  },
+  paginationOptions: {
+    display: 'flex',
+    fontSize: '13px',
+  },
 });
 
 interface Props {
@@ -121,6 +141,8 @@ interface State {
   jobIds: string[];
   jobs: JobsObject;
   openJob: string;
+  page: number;
+  rowsPerPage: number;
 }
 
 const ErrorBox = (props: { errorMsg: string }) => {
@@ -290,6 +312,8 @@ class QueryHistoryPanel extends React.Component<Props, State> {
       jobs: {} as JobsObject,
       jobIds: [],
       openJob: null,
+      page: 0,
+      rowsPerPage: 30,
     };
   }
 
@@ -364,6 +388,17 @@ class QueryHistoryPanel extends React.Component<Props, State> {
     }
   }
 
+  handleChangePage(event, newPage) {
+    this.setState({ page: newPage });
+  }
+
+  handleChangeRowsPerPage(event) {
+    this.setState({
+      rowsPerPage: parseInt(event.target.value, 10),
+    });
+    this.setState({ page: 0 });
+  }
+
   render() {
     if (this.state.isLoading) {
       return (
@@ -372,8 +407,11 @@ class QueryHistoryPanel extends React.Component<Props, State> {
         </>
       );
     } else {
-      const { jobs, jobIds, openJob } = this.state;
-      const queriesByDate = this.processHistory(jobIds, jobs);
+      const { jobs, jobIds, openJob, rowsPerPage, page } = this.state;
+      const queriesByDate = this.processHistory(
+        jobIds.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
+        jobs
+      );
 
       return (
         <div className={localStyles.queryHistoryRoot}>
@@ -423,6 +461,18 @@ class QueryHistoryPanel extends React.Component<Props, State> {
               );
             })}
           </div>
+          <TablePagination
+            className={localStyles.pagination}
+            rowsPerPageOptions={[10, 30, 50, 100, 200]}
+            component="div"
+            count={jobIds.length}
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onChangePage={this.handleChangePage.bind(this)}
+            onChangeRowsPerPage={this.handleChangeRowsPerPage.bind(this)}
+            ActionsComponent={TablePaginationActions}
+            labelRowsPerPage="Queries per page:"
+          />
         </div>
       );
     }

--- a/jupyterlab_bigquery/src/components/shared/bq_table.tsx
+++ b/jupyterlab_bigquery/src/components/shared/bq_table.tsx
@@ -65,7 +65,7 @@ interface TablePaginationActionsProps {
   ) => void;
 }
 
-function TablePaginationActions(props: TablePaginationActionsProps) {
+export function TablePaginationActions(props: TablePaginationActionsProps) {
   const { count, page, rowsPerPage, onChangePage } = props;
 
   const handleFirstPageButtonClick = (

--- a/jupyterlab_bigquery/src/components/shared/read_only_editor.tsx
+++ b/jupyterlab_bigquery/src/components/shared/read_only_editor.tsx
@@ -53,6 +53,9 @@ const READ_ONLY_SQL_EDITOR_OPTIONS: editor.IEditorConstructionOptions = {
   occurrencesHighlight: false,
   folding: false,
   scrollBeyondLastLine: false,
+  scrollbar: {
+    handleMouseWheel: false,
+  },
 };
 
 const ReadOnlyEditor = props => {


### PR DESCRIPTION
Prevents lag from rendering too many queries at once in Query History, and instead follows a similar pagination UI to the query results.

This solution was chosen because infinite scroll solutions proved difficult with the expanding panels and non-static sizing.

![pagination](https://user-images.githubusercontent.com/48393093/90832798-9d87df80-e314-11ea-8cfd-253957cc0bf1.png)
