### PR TITLE
[HardwareConfiguration] Fixing sizing issue with details dialog body

### DIFF
--- a/jupyterlab_gcedetails/src/components/details_dialog_body.tsx
+++ b/jupyterlab_gcedetails/src/components/details_dialog_body.tsx
@@ -42,25 +42,27 @@ export function DetailsDialogBody(props: Props) {
   const { details, receivedError, onDialogClose, reshapeForm } = props;
   return (
     <dl className={STYLES.containerPadding}>
-      <div className={STYLES.containerSize}>
-        <p className={classes(STYLES.heading, DIALOG_STYLES.headingPadding)}>
-          Notebook VM Details
-        </p>
-        {loadingDetails(Boolean(details), receivedError) ? (
+      <p className={classes(STYLES.heading, DIALOG_STYLES.headingPadding)}>
+        Notebook VM Details
+      </p>
+      {loadingDetails(Boolean(details), receivedError) ? (
+        <div className={STYLES.containerSize}>
           <p className={STYLES.paragraph}>Retrieving GCE VM details...</p>
-        ) : receivedError ? (
+        </div>
+      ) : receivedError ? (
+        <div className={STYLES.containerSize}>
           <p className={STYLES.paragraph}>
             Unable to retrieve GCE VM details, please check your server logs
           </p>
-        ) : (
-          MAPPED_ATTRIBUTES.map(am => (
-            <div className={STYLES.listRow} key={am.label}>
-              <dt className={STYLES.dt}>{am.label}</dt>
-              <dd className={STYLES.dd}>{am.mapper(details)}</dd>
-            </div>
-          ))
-        )}
-      </div>
+        </div>
+      ) : (
+        MAPPED_ATTRIBUTES.map(am => (
+          <div className={STYLES.listRow} key={am.label}>
+            <dt className={STYLES.dt}>{am.label}</dt>
+            <dd className={STYLES.dd}>{am.mapper(details)}</dd>
+          </div>
+        ))
+      )}
       <ActionBar
         primaryLabel="Update"
         secondaryLabel="Close"


### PR DESCRIPTION
Originally had a size container wrapping around the details table which caused some extra space to the left when the details didn't take up the full space. Removed the size container and added it to just the error and loading messages.

https://screencast.googleplex.com/cast/NjY5MTU3NDg0NTAxNDAxNnw4ZDM5NjE0Ni1kNQ
