### PR TITLE
[HardwareConfiguration] Fetching gpus from client

### DIFF
--- a/jupyterlab_gcedetails/jupyterlab_gcedetails/handlers.py
+++ b/jupyterlab_gcedetails/jupyterlab_gcedetails/handlers.py
@@ -30,11 +30,9 @@ METADATA_SERVER = os.environ.get(
     'http://metadata.google.internal') + '/computeMetadata/v1/?recursive=true'
 METADATA_HEADER = {'Metadata-Flavor': 'Google'}
 MACHINE_TYPE_CMD = 'gcloud compute machine-types describe'
-ACCELERATOR_TYPES_CMD = 'gcloud compute accelerator-types list --format="json"'
 NVIDIA_CMD = 'nvidia-smi -q -x'
 
 # Constants for field names
-ACCELERATOR_TYPES = 'acceleratorTypes'
 CPU = 'cpu'
 CUDA_VERSION = 'cuda_version'
 COUNT = 'count'
@@ -132,26 +130,6 @@ async def get_gpu_details():
 
   return details
 
-
-async def get_gpu_list(zone):
-  """Uses gcloud to return a list of available Accelerator Types."""
-  accelerator_types = []
-  zone = zone[zone.rindex('/') + 1:]
-  app_log.debug('Getting Accelerator Types from gcloud')
-  process = await asyncio.create_subprocess_shell(
-      '{} --filter="zone:{}"'.format(ACCELERATOR_TYPES_CMD, zone),
-      stdout=asyncio.subprocess.PIPE,
-      stderr=asyncio.subprocess.PIPE)
-  stdout, _ = await process.communicate()
-
-  if process.returncode != 0:
-    app_log.error('Unable to obtain Accelerator Types from gcloud')
-    return accelerator_types
-
-  accelerator_types = json.loads(stdout.decode())
-  return accelerator_types
-
-
 class VmDetailsHandler(APIHandler):
   """Handler to obtain details from the metadata server and local system."""
 
@@ -169,7 +147,6 @@ class VmDetailsHandler(APIHandler):
       zone = instance.get(ZONE, '')
       instance[MACHINE_TYPE] = await get_machine_type_details(
           zone, machine_type)
-      metadata[ACCELERATOR_TYPES] = await get_gpu_list(zone)
       self.details.update(metadata)
 
     self.details[UTILIZATION] = get_resource_utilization()

--- a/jupyterlab_gcedetails/jupyterlab_gcedetails/handlers_test.py
+++ b/jupyterlab_gcedetails/jupyterlab_gcedetails/handlers_test.py
@@ -64,55 +64,6 @@ class GetMetadataTest(tornado.testing.AsyncTestCase):
 
 
 @patch('asyncio.create_subprocess_shell')
-class GetGpuListTest(tornado.testing.AsyncTestCase):
-
-  @tornado.testing.gen_test
-  async def test_get_gpu_list(self, mock_create_subprocess):
-    mock_process = MagicMock()
-    mock_process.returncode = 0
-    mock_process.communicate = MagicMock(
-        return_value=async_return((test_data.ACCELERATOR_LIST_STDOUT, '')))
-    mock_create_subprocess.return_value = async_return(mock_process)
-
-    gpu_list = await handlers.get_gpu_list(test_data.ZONE)
-    self.assertEqual([{
-        "creationTimestamp":
-            "1969-12-31T16:00:00.000-08:00",
-        "description":
-            "NVIDIA Tesla K80",
-        "id":
-            "10002",
-        "kind":
-            "compute#acceleratorType",
-        "maximumCardsPerInstance":
-            8,
-        "name":
-            "nvidia-tesla-k80",
-        "selfLink":
-            "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b/acceleratorTypes/nvidia-tesla-k80",
-        "zone":
-            "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b"
-    }], gpu_list)
-    self.assertEqual(
-        handlers.ACCELERATOR_TYPES_CMD + ' --filter="zone:us-west1-b"',
-        mock_create_subprocess.call_args[0][0])
-
-  @tornado.testing.gen_test
-  async def test_get_gpu_list_is_empty_on_err(self, mock_create_subprocess):
-    mock_process = MagicMock()
-    mock_process.returncode = -1
-    mock_process.communicate = MagicMock(
-        return_value=async_return(('', 'gcloud failed')))
-    mock_create_subprocess.return_value = async_return(mock_process)
-
-    gpu_list = await handlers.get_gpu_list(test_data.ZONE)
-    self.assertEqual([], gpu_list)
-    self.assertEqual(
-        handlers.ACCELERATOR_TYPES_CMD + ' --filter="zone:us-west1-b"',
-        mock_create_subprocess.call_args[0][0])
-
-
-@patch('asyncio.create_subprocess_shell')
 class GetMachineTypeDetailsTest(tornado.testing.AsyncTestCase):
 
   @tornado.testing.gen_test
@@ -225,7 +176,6 @@ class GetGpuDetailsTest(tornado.testing.AsyncTestCase):
 
 @patch(__name__ + '.handlers.get_resource_utilization')
 @patch(__name__ + '.handlers.get_gpu_details')
-@patch(__name__ + '.handlers.get_gpu_list')
 @patch(__name__ + '.handlers.get_machine_type_details')
 @patch(__name__ + '.handlers.get_metadata')
 class VmDetailsHandlerTest(tornado.testing.AsyncHTTPTestCase):
@@ -238,16 +188,13 @@ class VmDetailsHandlerTest(tornado.testing.AsyncHTTPTestCase):
     ])
 
   def test_get(self, mock_get_metadata, mock_get_machine_type_details,
-               mock_get_gpu_list, mock_get_gpu_details,
-               mock_get_resource_utilization):
+               mock_get_gpu_details, mock_get_resource_utilization):
     mock_get_metadata.return_value = async_return(
         json.loads(test_data.METADATA_RESPONSE_BODY))
     mock_get_machine_type_details.return_value = async_return({
         'name': 'n1-standard-4',
         'description': '4 vCPU, 15 GB RAM'
     })
-    mock_get_gpu_list.return_value = async_return(
-        json.loads(test_data.ACCELERATOR_LIST_STDOUT))
     mock_get_gpu_details.return_value = async_return({
         'cuda_version': '10.1',
         'driver_version': '418.87.01',
@@ -266,8 +213,6 @@ class VmDetailsHandlerTest(tornado.testing.AsyncHTTPTestCase):
         'projects/123456/zones/us-west1-b',
         'projects/123456/machineTypes/n1-standard-1')
     mock_get_gpu_details.assert_called_once()
-    mock_get_gpu_list.assert_called_once_with(
-        'projects/123456/zones/us-west1-b')
     mock_get_resource_utilization.assert_called_once()
 
     # Second call should use cached metadata, gpu list and machine type details
@@ -278,8 +223,6 @@ class VmDetailsHandlerTest(tornado.testing.AsyncHTTPTestCase):
     mock_get_machine_type_details.assert_called_once_with(
         'projects/123456/zones/us-west1-b',
         'projects/123456/machineTypes/n1-standard-1')
-    mock_get_gpu_list.assert_called_once_with(
-        'projects/123456/zones/us-west1-b')
     self.assertEqual(2, mock_get_gpu_details.call_count)
     self.assertEqual(2, mock_get_resource_utilization.call_count)
 

--- a/jupyterlab_gcedetails/jupyterlab_gcedetails/test_data.py
+++ b/jupyterlab_gcedetails/jupyterlab_gcedetails/test_data.py
@@ -421,21 +421,6 @@ NVIDIA_SMI_STDOUT = b"""<?xml version="1.0" ?>
 </nvidia_smi_log>
 """
 
-ACCELERATOR_LIST_STDOUT = b"""
-[
-  {
-    "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
-    "description": "NVIDIA Tesla K80",
-    "id": "10002",
-    "kind": "compute#acceleratorType",
-    "maximumCardsPerInstance": 8,
-    "name": "nvidia-tesla-k80",
-    "selfLink": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b/acceleratorTypes/nvidia-tesla-k80",
-    "zone": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b"
-  }
-]
-"""
-
 DETAILS_RESPONSE_BODY = (
     b'{"instance": {"attributes": {"framework": "PyTorch:1.4", '
     b'"install-nvidia-driver": "True", "notebooks-api": "PROD", "proxy-mode": '
@@ -474,12 +459,6 @@ DETAILS_RESPONSE_BODY = (
     b' "0"}, "zone": "projects/123456/zones/us-west1-b"}, "oslogin": '
     b'{"authenticate": {"sessions": {}}}, "project": {"attributes": {}, '
     b'"numericProjectId": 123456, "projectId": "test-project"}, '
-    b'"acceleratorTypes": [{"creationTimestamp": "1969-12-31T16:00:00.000-08:00",'
-    b' "description": "NVIDIA Tesla K80", "id": "10002", "kind":'
-    b' "compute#acceleratorType", "maximumCardsPerInstance": 8,'
-    b' "name": "nvidia-tesla-k80", "selfLink": '
-    b'"https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b/acceleratorTypes/nvidia-tesla-k80",'
-    b' "zone": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b"'
-    b'}], "utilization": {"cpu": 50, "memory": 16}, "gpu": {"cuda_version":'
+    b'"utilization": {"cpu": 50, "memory": 16}, "gpu": {"cuda_version":'
     b' "10.1", "driver_version": "418.87.01", "gpu": 100, "count": 1, "memory":'
     b' 6, "name": "Tesla K80", "temperature": "42 C"}}')

--- a/jupyterlab_gcedetails/src/data/accelerator_types.ts
+++ b/jupyterlab_gcedetails/src/data/accelerator_types.ts
@@ -100,6 +100,8 @@ export function getGpuTypeOptionsList(
   accelerators: Accelerator[],
   cpuPlatform: string
 ): Option[] {
+  if (!accelerators || accelerators.length === 0) return ACCELERATOR_TYPES;
+
   // For more information on gpu restrictions see: https://cloud.google.com/compute/docs/gpus#restrictions
   accelerators = accelerators.filter(
     accelerator =>
@@ -125,7 +127,7 @@ export function getGpuCountOptionsList(
   accelerators: Accelerator[],
   acceleratorName: string
 ): Option[] {
-  if (acceleratorName === NO_ACCELERATOR_TYPE)
+  if (!acceleratorName || acceleratorName === NO_ACCELERATOR_TYPE)
     return ACCELERATOR_COUNTS_1_2_4_8;
 
   const accelerator = accelerators.find(

--- a/jupyterlab_gcedetails/src/details_widget.spec.tsx
+++ b/jupyterlab_gcedetails/src/details_widget.spec.tsx
@@ -21,7 +21,11 @@ import * as React from 'react';
 import { VmDetails } from './details_widget';
 import { STYLES } from './data/styles';
 import { ServerWrapper } from './components/server_wrapper';
-import { DETAILS_RESPONSE, MACHINE_TYPES_RESPONSE } from './test_helpers';
+import {
+  DETAILS_RESPONSE,
+  MACHINE_TYPES_RESPONSE,
+  ACCELERATOR_TYPES_RESPONSE,
+} from './test_helpers';
 import { NotebooksService } from './service/notebooks_service';
 import { ClientTransportService } from 'gcp_jupyterlab_shared';
 import { HardwareConfigurationDialog } from './components/hardware_configuration_dialog';
@@ -30,6 +34,7 @@ import { DetailsService } from './service/details_service';
 describe('VmDetails', () => {
   const mockGetUtilizationData = jest.fn();
   const mockGetMachineTypes = jest.fn();
+  const mockGetAcceleratorTypes = jest.fn();
   const mockServerWrapper = ({
     getUtilizationData: mockGetUtilizationData,
   } as unknown) as ServerWrapper;
@@ -39,6 +44,7 @@ describe('VmDetails', () => {
   );
   const mockDetailsService = ({
     getMachineTypes: mockGetMachineTypes,
+    getAcceleratorTypes: mockGetAcceleratorTypes,
   } as unknown) as DetailsService;
 
   beforeEach(() => {
@@ -56,6 +62,8 @@ describe('VmDetails', () => {
     mockGetUtilizationData.mockReturnValue(details);
     const machineTypes = Promise.resolve(MACHINE_TYPES_RESPONSE);
     mockGetMachineTypes.mockReturnValue(machineTypes);
+    const acceleratorTypes = Promise.resolve(ACCELERATOR_TYPES_RESPONSE);
+    mockGetAcceleratorTypes.mockReturnValue(acceleratorTypes);
 
     const vmDetails = shallow(
       <VmDetails
@@ -65,11 +73,13 @@ describe('VmDetails', () => {
       />
     );
     expect(vmDetails).toMatchSnapshot('Retrieving');
-    await Promise.all([details, machineTypes]);
+    await details;
+    await Promise.all([machineTypes, acceleratorTypes]);
 
     expect(vmDetails).toMatchSnapshot('Details');
     expect(mockGetUtilizationData).toHaveBeenCalledTimes(1);
     expect(mockGetMachineTypes).toHaveBeenCalledTimes(1);
+    expect(mockGetAcceleratorTypes).toHaveBeenCalledTimes(1);
   });
 
   it('Renders with get details error', async () => {
@@ -102,6 +112,8 @@ describe('VmDetails', () => {
     mockGetUtilizationData.mockReturnValue(details);
     const machineTypes = Promise.resolve(MACHINE_TYPES_RESPONSE);
     mockGetMachineTypes.mockReturnValue(machineTypes);
+    const acceleratorTypes = Promise.resolve(ACCELERATOR_TYPES_RESPONSE);
+    mockGetAcceleratorTypes.mockReturnValue(acceleratorTypes);
 
     const vmDetails = shallow(
       <VmDetails
@@ -110,7 +122,8 @@ describe('VmDetails', () => {
         detailsService={mockDetailsService}
       />
     );
-    await Promise.all([details, machineTypes]);
+    await details;
+    await Promise.all([machineTypes, acceleratorTypes]);
 
     vmDetails.find('[title="Show all details"]').simulate('click');
     vmDetails.update();
@@ -124,6 +137,8 @@ describe('VmDetails', () => {
     mockGetUtilizationData.mockReturnValue(details);
     const machineTypes = Promise.resolve(MACHINE_TYPES_RESPONSE);
     mockGetMachineTypes.mockReturnValue(machineTypes);
+    const acceleratorTypes = Promise.resolve(ACCELERATOR_TYPES_RESPONSE);
+    mockGetAcceleratorTypes.mockReturnValue(acceleratorTypes);
 
     const vmDetails = shallow(
       <VmDetails
@@ -132,7 +147,12 @@ describe('VmDetails', () => {
         detailsService={mockDetailsService}
       />
     );
-    await Promise.all([details, machineTypes]);
+    await details;
+    await Promise.all([machineTypes, acceleratorTypes]);
+
+    expect(mockGetUtilizationData).toHaveBeenCalledTimes(1);
+    expect(mockGetMachineTypes).toHaveBeenCalledTimes(1);
+    expect(mockGetAcceleratorTypes).toHaveBeenCalledTimes(1);
 
     let attributes = vmDetails.find(`span.${STYLES.attribute}`);
     expect(attributes.length).toBe(2);
@@ -168,6 +188,8 @@ describe('VmDetails', () => {
     mockGetUtilizationData.mockReturnValue(details);
     const machineTypes = Promise.resolve(MACHINE_TYPES_RESPONSE);
     mockGetMachineTypes.mockReturnValue(machineTypes);
+    const acceleratorTypes = Promise.resolve(ACCELERATOR_TYPES_RESPONSE);
+    mockGetAcceleratorTypes.mockReturnValue(acceleratorTypes);
 
     const vmDetails = shallow(
       <VmDetails
@@ -176,10 +198,12 @@ describe('VmDetails', () => {
         detailsService={mockDetailsService}
       />
     );
-    await Promise.all([details, machineTypes]);
+    await details;
+    await Promise.all([machineTypes, acceleratorTypes]);
 
     expect(mockGetUtilizationData).toHaveBeenCalledTimes(1);
     expect(mockGetMachineTypes).toHaveBeenCalledTimes(1);
+    expect(mockGetAcceleratorTypes).toHaveBeenCalledTimes(1);
     // Click four times to move to CPU usage
     for (let i = 0; i < 4; i++) {
       vmDetails

--- a/jupyterlab_gcedetails/src/details_widget.tsx
+++ b/jupyterlab_gcedetails/src/details_widget.tsx
@@ -129,11 +129,11 @@ export class VmDetails extends React.Component<Props, State> {
         detailsService.getMachineTypes(),
         detailsService.getAcceleratorTypes(),
       ]);
+
       details.machineTypes = getMachineTypeConfigurations(machineTypes);
       details.acceleratorTypes = acceleratorTypes;
-      console.log(acceleratorTypes);
 
-      this.setState({ details: details });
+      this.setState({ details });
     } catch (e) {
       console.warn('Unable to retrieve GCE VM details');
       this.setState({ receivedError: true });

--- a/jupyterlab_gcedetails/src/details_widget.tsx
+++ b/jupyterlab_gcedetails/src/details_widget.tsx
@@ -125,8 +125,13 @@ export class VmDetails extends React.Component<Props, State> {
       detailsService.projectId = details.project.projectId;
       detailsService.zone = zone;
 
-      const machineTypes = await detailsService.getMachineTypes();
+      const [machineTypes, acceleratorTypes] = await Promise.all([
+        detailsService.getMachineTypes(),
+        detailsService.getAcceleratorTypes(),
+      ]);
       details.machineTypes = getMachineTypeConfigurations(machineTypes);
+      details.acceleratorTypes = acceleratorTypes;
+      console.log(acceleratorTypes);
 
       this.setState({ details: details });
     } catch (e) {

--- a/jupyterlab_gcedetails/src/service/details_service.spec.ts
+++ b/jupyterlab_gcedetails/src/service/details_service.spec.ts
@@ -29,7 +29,10 @@ jest.mock('gcp_jupyterlab_shared', () => {
 import { asApiResponse } from 'gcp_jupyterlab_shared';
 import { DetailsService, COMPUTE_ENGINE_API_PATH } from './details_service';
 import { ServerProxyTransportService } from 'gcp_jupyterlab_shared';
-import { MACHINE_TYPES_RESPONSE } from '../test_helpers';
+import {
+  MACHINE_TYPES_RESPONSE,
+  ACCELERATOR_TYPES_RESPONSE,
+} from '../test_helpers';
 
 const TEST_PROJECT = 'test-project';
 const TEST_ZONE = 'test-zone';
@@ -89,6 +92,45 @@ describe('DetailsService', () => {
         params: {
           filter: 'isSharedCpu = false',
         },
+      });
+    });
+  });
+
+  describe('Get Accelerator Types', () => {
+    it('Gets all accelerator types', async () => {
+      mockSubmit.mockResolvedValue(
+        asApiResponse({
+          items: ACCELERATOR_TYPES_RESPONSE,
+        })
+      );
+
+      const response = await detailsService.getAcceleratorTypes();
+
+      expect(mockSubmit).toHaveBeenCalledWith({
+        path: `${COMPUTE_ENGINE_API_PATH}/${name}/acceleratorTypes`,
+      });
+      expect(response).toEqual(ACCELERATOR_TYPES_RESPONSE);
+    });
+
+    it('Fails to get accelerator types', async () => {
+      mockSubmit.mockResolvedValue(
+        asApiResponse({
+          done: true,
+          error: {
+            code: 400,
+            message: 'Unable to retrieve accelerator types.',
+          },
+        })
+      );
+
+      try {
+        await detailsService.getAcceleratorTypes();
+      } catch (err) {
+        expect(err).toEqual('Unable to retrieve accelerator types.');
+      }
+
+      expect(mockSubmit).toHaveBeenCalledWith({
+        path: `${COMPUTE_ENGINE_API_PATH}/${name}/acceleratorTypes`,
       });
     });
   });

--- a/jupyterlab_gcedetails/src/service/details_service.ts
+++ b/jupyterlab_gcedetails/src/service/details_service.ts
@@ -33,7 +33,7 @@ export class DetailsService {
   private zonePromise?: Promise<string>;
   private metadataPromise?: Promise<InstanceMetadata>;
   private machineTypesPromise?: Promise<GapiMachineType[]>;
-  private acceleratorTypesPromise?: Promise<any>;
+  private acceleratorTypesPromise?: Promise<Accelerator[]>;
 
   constructor(
     private _transportService: ServerProxyTransportService,
@@ -166,7 +166,9 @@ export class DetailsService {
       >({
         path: `${COMPUTE_ENGINE_API_PATH}/${name}/acceleratorTypes`,
       });
-      this.acceleratorTypesPromise = Promise.resolve(response.result.items);
+      this.acceleratorTypesPromise = Promise.resolve(
+        response.result.items as Accelerator[]
+      );
       return this.acceleratorTypesPromise;
     } catch (err) {
       console.error(`Unable to retrieve accelerator types.`);

--- a/jupyterlab_gcedetails/src/test_helpers.ts
+++ b/jupyterlab_gcedetails/src/test_helpers.ts
@@ -212,6 +212,81 @@ export const MACHINE_TYPES_RESPONSE = [
   },
 ];
 
+export const ACCELERATOR_TYPES_RESPONSE = [
+  {
+    id: '10002',
+    creationTimestamp: '1969-12-31T16:00:00.000-08:00',
+    name: 'nvidia-tesla-k80',
+    description: 'NVIDIA Tesla K80',
+    zone:
+      'https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b',
+    selfLink:
+      'https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b/acceleratorTypes/nvidia-tesla-k80',
+    maximumCardsPerInstance: 8,
+    kind: 'compute#acceleratorType',
+  },
+  {
+    id: '10004',
+    creationTimestamp: '1969-12-31T16:00:00.000-08:00',
+    name: 'nvidia-tesla-p100',
+    description: 'NVIDIA Tesla P100',
+    zone:
+      'https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b',
+    selfLink:
+      'https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b/acceleratorTypes/nvidia-tesla-p100',
+    maximumCardsPerInstance: 4,
+    kind: 'compute#acceleratorType',
+  },
+  {
+    id: '10007',
+    creationTimestamp: '1969-12-31T16:00:00.000-08:00',
+    name: 'nvidia-tesla-p100-vws',
+    description: 'NVIDIA Tesla P100 Virtual Workstation',
+    zone:
+      'https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b',
+    selfLink:
+      'https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b/acceleratorTypes/nvidia-tesla-p100-vws',
+    maximumCardsPerInstance: 4,
+    kind: 'compute#acceleratorType',
+  },
+  {
+    id: '10019',
+    creationTimestamp: '1969-12-31T16:00:00.000-08:00',
+    name: 'nvidia-tesla-t4',
+    description: 'NVIDIA Tesla T4',
+    zone:
+      'https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b',
+    selfLink:
+      'https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b/acceleratorTypes/nvidia-tesla-t4',
+    maximumCardsPerInstance: 4,
+    kind: 'compute#acceleratorType',
+  },
+  {
+    id: '10020',
+    creationTimestamp: '1969-12-31T16:00:00.000-08:00',
+    name: 'nvidia-tesla-t4-vws',
+    description: 'NVIDIA Tesla T4 Virtual Workstation',
+    zone:
+      'https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b',
+    selfLink:
+      'https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b/acceleratorTypes/nvidia-tesla-t4-vws',
+    maximumCardsPerInstance: 4,
+    kind: 'compute#acceleratorType',
+  },
+  {
+    id: '10008',
+    creationTimestamp: '1969-12-31T16:00:00.000-08:00',
+    name: 'nvidia-tesla-v100',
+    description: 'NVIDIA Tesla V100',
+    zone:
+      'https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b',
+    selfLink:
+      'https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b/acceleratorTypes/nvidia-tesla-v100',
+    maximumCardsPerInstance: 8,
+    kind: 'compute#acceleratorType',
+  },
+];
+
 /** Returns a Promise that resolves a JSON response akin to the fetch API */
 export function asFetchResponse(result: any, ok = true): Promise<Response> {
   return Promise.resolve({


### PR DESCRIPTION
Removing the code to fetch the list of available GPUs using gcloud compute in the server and instead fetching them in the client using the Compute API.