### PR TITLE
[HardwareConfiguration] Displaying instance details in reshape complete message

### DIFF
--- a/jupyterlab_gcedetails/src/components/__snapshots__/hardware_scaling_status.spec.tsx.snap
+++ b/jupyterlab_gcedetails/src/components/__snapshots__/hardware_scaling_status.spec.tsx.snap
@@ -18,6 +18,11 @@ exports[`HardwareScalingStatus Renders with operation error: Operation error 1`]
   }
   instanceDetails={
     Object {
+      "acceleratorConfig": Object {
+        "coreCount": "1",
+        "type": "NVIDIA_TESLA_K80",
+      },
+      "machineType": "https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b/machineTypes/e2-highmem-8",
       "name": "Test",
     }
   }
@@ -92,6 +97,24 @@ exports[`HardwareScalingStatus Runs through reshaping flow: Complete 1`] = `
     >
       Operation complete. Enjoy your newly configured instance!
     </p>
+    <div>
+      <span
+        className="subheading_fgjqs4u"
+      >
+        Your new configuration:
+      </span>
+      <div
+        className="paragraph_fssm9cv"
+      >
+        Machine type: 
+        Efficient Instance, 8 vCPUs, 64 GB RAM
+      </div>
+      <div
+        className="paragraph_fssm9cv"
+      >
+        GPUs: 1 NVIDIA Tesla K80
+      </div>
+    </div>
   </div>
   <ActionBar
     onPrimaryClick={[MockFunction]}

--- a/jupyterlab_gcedetails/src/components/error_page.tsx
+++ b/jupyterlab_gcedetails/src/components/error_page.tsx
@@ -21,11 +21,8 @@ import { ConfigurationError, ErrorType } from './hardware_scaling_status';
 import { Instance } from '../service/notebooks_service';
 import { ActionBar } from './action_bar';
 import { STYLES } from '../data/styles';
-import { getGpuTypeText } from '../data/accelerator_types';
-import {
-  getMachineTypeText,
-  MachineTypeConfiguration,
-} from '../data/machine_types';
+import { MachineTypeConfiguration } from '../data/machine_types';
+import { displayInstance } from './instance_details_message';
 
 interface Props {
   instanceDetails?: Instance;
@@ -39,30 +36,6 @@ Cloud Console to continue using this Notebook. `;
 const LINK = `https://console.cloud.google.com/ai-platform/notebooks/`;
 const LINK_TEXT = `View Cloud Console`;
 
-function displayInstance(instance: Instance, machineTypes) {
-  const { machineType, acceleratorConfig } = instance;
-  const machineTypeText = getMachineTypeText(
-    machineType.split('/').pop(),
-    machineTypes
-  );
-
-  return (
-    <div>
-      <span className={STYLES.subheading}>Your current configuration:</span>
-      {machineTypeText && (
-        <div className={STYLES.paragraph}>Machine type: {machineTypeText}</div>
-      )}
-      {acceleratorConfig && (
-        <div className={STYLES.paragraph}>
-          {`GPUs: ${acceleratorConfig.coreCount} ${getGpuTypeText(
-            acceleratorConfig.type
-          )}`}
-        </div>
-      )}
-    </div>
-  );
-}
-
 export function ErrorPage(props: Props) {
   const { onDialogClose, error, instanceDetails, machineTypes } = props;
   const { errorType, errorValue } = error;
@@ -74,7 +47,12 @@ export function ErrorPage(props: Props) {
           className={STYLES.heading}
         >{`Failed to ${errorType} Your Machine`}</span>
         <div className={STYLES.paragraph}>{errorValue}</div>
-        {instanceDetails && displayInstance(instanceDetails, machineTypes)}
+        {instanceDetails &&
+          displayInstance(
+            instanceDetails,
+            machineTypes,
+            'Your current configuration:'
+          )}
         {errorType === ErrorType.START && (
           <div className={STYLES.infoMessage}>
             <Message asError={true} asActivity={false} text={ERROR_MESSAGE}>

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_status.spec.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_status.spec.tsx
@@ -33,6 +33,12 @@ describe('HardwareScalingStatus', () => {
   } as unknown) as NotebooksService;
   const mockInstance: Instance = {
     name: 'Test',
+    machineType:
+      'https://www.googleapis.com/compute/v1/projects/jupyterlab-interns-sandbox/zones/us-west1-b/machineTypes/e2-highmem-8',
+    acceleratorConfig: {
+      coreCount: '1',
+      type: 'NVIDIA_TESLA_K80',
+    },
   };
   const mockToken = 'mockToken';
 

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_status.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_status.tsx
@@ -8,6 +8,7 @@ import { NotebooksService, Instance } from '../service/notebooks_service';
 import { ServerWrapper } from './server_wrapper';
 import { ErrorPage } from './error_page';
 import { MachineTypeConfiguration } from '../data/machine_types';
+import { displayInstance } from './instance_details_message';
 
 const BorderLinearProgress = withStyles((theme: Theme) =>
   createStyles({
@@ -260,6 +261,12 @@ export class HardwareScalingStatus extends React.Component<Props, State> {
         <div className={STYLES.containerSize}>
           <p className={STYLES.heading}>{Status[status]}</p>
           <p className={STYLES.paragraph}>{statusInfo[status]}</p>
+          {status === Status['Complete'] &&
+            displayInstance(
+              instanceDetails,
+              machineTypes,
+              'Your new configuration:'
+            )}
         </div>
         {status === Status['Complete'] ? (
           <ActionBar onPrimaryClick={onDialogClose} primaryLabel="Close" />

--- a/jupyterlab_gcedetails/src/components/instance_details_message.tsx
+++ b/jupyterlab_gcedetails/src/components/instance_details_message.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+
+import { Instance } from '../service/notebooks_service';
+import {
+  MachineTypeConfiguration,
+  getMachineTypeText,
+} from '../data/machine_types';
+import { STYLES } from '../data/styles';
+import { getGpuTypeText } from '../data/accelerator_types';
+
+export function displayInstance(
+  instance: Instance,
+  machineTypes: MachineTypeConfiguration[],
+  title: string
+) {
+  const { machineType, acceleratorConfig } = instance;
+  const machineTypeText = getMachineTypeText(
+    machineType.split('/').pop(),
+    machineTypes
+  );
+
+  return (
+    <div>
+      <span className={STYLES.subheading}>{title}</span>
+      {machineTypeText && (
+        <div className={STYLES.paragraph}>Machine type: {machineTypeText}</div>
+      )}
+      {acceleratorConfig && (
+        <div className={STYLES.paragraph}>
+          {`GPUs: ${acceleratorConfig.coreCount} ${getGpuTypeText(
+            acceleratorConfig.type
+          )}`}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/jupyterlab_gcedetails/src/service/details_service.spec.ts
+++ b/jupyterlab_gcedetails/src/service/details_service.spec.ts
@@ -26,9 +26,11 @@ jest.mock('gcp_jupyterlab_shared', () => {
   };
 });
 
-import { asApiResponse } from 'gcp_jupyterlab_shared';
+import {
+  asApiResponse,
+  ServerProxyTransportService,
+} from 'gcp_jupyterlab_shared';
 import { DetailsService, COMPUTE_ENGINE_API_PATH } from './details_service';
-import { ServerProxyTransportService } from 'gcp_jupyterlab_shared';
 import {
   MACHINE_TYPES_RESPONSE,
   ACCELERATOR_TYPES_RESPONSE,


### PR DESCRIPTION
Adding new instance details to the message displayed in the dialog once reshaping completes successfully. These details are already displayed in the error page so I'm moving the function that formats them out into it's own component to be used by both the error page and the completion message.

![Screenshot 2020-08-24 at 6 28 58 PM](https://user-images.githubusercontent.com/28398459/91105041-10f35f00-e63d-11ea-805b-e5f0b4c497a0.png)
