### PR TITLE
[BigQuery] Show message when there are no search results

### DIFF
--- a/jupyterlab_bigquery/src/components/list_items_panel/list_search_results.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_search_results.tsx
@@ -207,10 +207,14 @@ export default class ListSearchResults extends React.Component<
 
   render() {
     const { context, searchResults } = this.props;
-    return searchResults.map(result => (
-      <div key={result.id} className={localStyles.root}>
-        {BuildSearchResult(result, context)}
-      </div>
-    ));
+    if (searchResults.length > 0) {
+      return searchResults.map(result => (
+        <div key={result.id} className={localStyles.root}>
+          {BuildSearchResult(result, context)}
+        </div>
+      ));
+    } else {
+      return <div>No items match your search.</div>;
+    }
   }
 }


### PR DESCRIPTION
Rather than a blank panel, now there is a message displayed when no search results arise.

![nosearch](https://user-images.githubusercontent.com/48393093/91314848-fd531000-e784-11ea-9c9c-eab33b576e71.png)
