### PR TITLE
[BigQuery] Common info card

### DIFF
--- a/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@material-ui/core';
-import { Code } from '@material-ui/icons';
+import { Code, Info } from '@material-ui/icons';
 
 import {
   TableDetailsService,
@@ -16,6 +16,7 @@ import { WidgetManager } from '../../utils/widgetManager/widget_manager';
 import { generateQueryId } from '../../reducers/queryEditorTabSlice';
 import { stylesheet } from 'typestyle';
 import { BASE_FONT } from 'gcp_jupyterlab_shared';
+import InfoCard from '../shared/info_card';
 
 export const localStyles = stylesheet({
   body: {
@@ -40,6 +41,7 @@ interface Props {
   isVisible: boolean;
   table_id: string;
   table_name: string;
+  partitioned: boolean;
 }
 
 interface State {
@@ -48,6 +50,7 @@ interface State {
   details: TableDetails;
   rows: DetailRow[];
   currentTab: number;
+  showPartitionCard: boolean;
 }
 
 interface DetailRow {
@@ -69,6 +72,7 @@ export default class TableDetailsTabs extends React.Component<Props, State> {
       details: { details: {} } as TableDetails,
       rows: [],
       currentTab: TabInds.details,
+      showPartitionCard: true,
     };
   }
 
@@ -105,6 +109,35 @@ export default class TableDetailsTabs extends React.Component<Props, State> {
             </Button>
           </Header>
           <div className={localStyles.body}>
+            {this.props.partitioned && this.state.showPartitionCard && (
+              <InfoCard
+                message={
+                  <div>
+                    This is a partitioned table.{' '}
+                    <a
+                      style={{ textDecoration: 'underline' }}
+                      href="https://cloud.google.com/bigquery/docs/partitioned-tables?_ga=2.65379946.-555088760.1592854116"
+                      target="_blank"
+                    >
+                      Learn more
+                    </a>
+                  </div>
+                }
+                color="gray"
+                icon={<Info />}
+                button={
+                  <Button
+                    size="small"
+                    style={{ textTransform: 'none' }}
+                    onClick={() => {
+                      this.setState({ showPartitionCard: false });
+                    }}
+                  >
+                    Dismiss
+                  </Button>
+                }
+              />
+            )}
             <StyledTabs
               value={this.state.currentTab}
               onChange={this.handleChange.bind(this)}

--- a/jupyterlab_bigquery/src/components/details_panel/table_details_widget.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_widget.tsx
@@ -29,6 +29,7 @@ export class TableDetailsWidget extends ReactWidget {
         isVisible={this.isVisible}
         table_id={this.table_id}
         table_name={this.name}
+        partitioned={this.partitioned}
         tableDetailsService={this.service}
       />
     );

--- a/jupyterlab_bigquery/src/components/details_panel/table_preview.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_preview.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { stylesheet } from 'typestyle';
+import { Warning } from '@material-ui/icons';
 
 import LoadingPanel from '../loading_panel';
 import {
@@ -7,6 +8,7 @@ import {
   TablePreview,
 } from './service/list_table_details';
 import { BQTable } from '../shared/bq_table';
+import InfoCard from '../shared/info_card';
 
 const localStyles = stylesheet({
   previewBody: {
@@ -14,6 +16,7 @@ const localStyles = stylesheet({
     minHeight: 0,
     display: 'flex',
     flexDirection: 'column',
+    paddingTop: '12px',
   },
 });
 
@@ -83,13 +86,18 @@ export default class TablePreviewPanel extends React.Component<Props, State> {
         <div className={localStyles.previewBody}>
           {rows.length > 0 ? (
             <div className={localStyles.previewBody}>
-              <br />
               <div>(First 100 rows)</div>
               <br />
               <BQTable rows={rows} fields={fields} />
             </div>
           ) : (
-            <div>This table is empty.</div>
+            <div className={localStyles.previewBody}>
+              <InfoCard
+                color="#FBBC04"
+                message="This table is empty."
+                icon={<Warning />}
+              />
+            </div>
           )}
         </div>
       );

--- a/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
+++ b/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
@@ -27,6 +27,7 @@ import { WidgetManager } from '../../utils/widgetManager/widget_manager';
 import { generateQueryId } from '../../reducers/queryEditorTabSlice';
 import { formatTime, formatDate, formatBytes } from '../../utils/formatters';
 import { TablePaginationActions } from '../shared/bq_table';
+import InfoCard from '../shared/info_card';
 import { BASE_FONT } from 'gcp_jupyterlab_shared';
 
 const localStyles = stylesheet({
@@ -146,30 +147,6 @@ interface State {
   lastFetchTime: number;
 }
 
-const ErrorBox = (props: { errorMsg: string }) => {
-  return (
-    <Paper
-      style={{
-        display: 'flex',
-        alignItems: 'stretch',
-        marginBottom: '12px',
-      }}
-      elevation={1}
-      variant="outlined"
-    >
-      <div style={{ width: '6px', backgroundColor: '#e60000' }} />
-      <div style={{ padding: '8px', display: 'flex', alignItems: 'center' }}>
-        <Error
-          fontSize="default"
-          htmlColor="rgb(230, 0, 0)"
-          className={localStyles.icon}
-        />
-        {props.errorMsg}
-      </div>
-    </Paper>
-  );
-};
-
 const QueryDetails = (props: { job: Job }) => {
   const { details, created, errored, query } = props.job;
   const rows = [
@@ -233,7 +210,13 @@ const QueryDetails = (props: { job: Job }) => {
         </button>
       </div>
 
-      {errored && <ErrorBox errorMsg={details.errorResult.message} />}
+      {errored && (
+        <InfoCard
+          color="#DA4336"
+          message={details.errorResult.message}
+          icon={<Error />}
+        />
+      )}
 
       <div style={{ marginBottom: '12px' }}>
         <ReadOnlyEditor query={query} />

--- a/jupyterlab_bigquery/src/components/shared/info_card.tsx
+++ b/jupyterlab_bigquery/src/components/shared/info_card.tsx
@@ -24,13 +24,15 @@ const localStyles = stylesheet({
   },
 });
 
+// TODO: figure out type so only material ui icons accepted,
+// and make it work with using .type
+type MaterialUIIcon = any;
+
 interface InfoCardProps {
   message: React.ReactNode;
   button?: React.ReactNode;
   color: string;
-  // TODO: figure out type so only material ui icons accepted,
-  // and make it work with using .type
-  icon: any;
+  icon: MaterialUIIcon;
 }
 
 // Card with matching colored strip and icon, and info message

--- a/jupyterlab_bigquery/src/components/shared/info_card.tsx
+++ b/jupyterlab_bigquery/src/components/shared/info_card.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { Paper } from '@material-ui/core';
+import { stylesheet } from 'typestyle';
+
+const localStyles = stylesheet({
+  container: {
+    display: 'flex',
+    alignItems: 'stretch',
+    marginBottom: '12px',
+    backgroundColor: 'var(--jp-layout-color0)',
+    justifyContent: 'space-between',
+    paddingRight: '12px',
+  },
+  leftSide: {
+    display: 'flex',
+  },
+  icon: {
+    marginRight: '12px',
+  },
+  messageSpace: {
+    padding: '4px 8px',
+    display: 'flex',
+    alignItems: 'center',
+  },
+});
+
+interface InfoCardProps {
+  message: React.ReactNode;
+  button?: React.ReactNode;
+  color: string;
+  // TODO: figure out type so only material ui icons accepted,
+  // and make it work with using .type
+  icon: any;
+}
+
+// Card with matching colored strip and icon, and info message
+const InfoCard = (props: InfoCardProps) => {
+  const { message, color, icon, button } = props;
+  return (
+    <Paper className={localStyles.container} variant="outlined">
+      <div className={localStyles.leftSide}>
+        <div style={{ width: '6px', backgroundColor: color }} />
+        <div className={localStyles.messageSpace}>
+          <icon.type
+            {...icon.props}
+            className={localStyles.icon}
+            style={{ color: color }}
+            fontSize="default"
+          />
+          {message}
+        </div>
+      </div>
+      {button}
+    </Paper>
+  );
+};
+
+export default InfoCard;


### PR DESCRIPTION
Pulls out the error box from query history and makes it a common component, `InfoCard`, reused for empty tables and partitioned tables.

`InfoCard` takes in a color, icon, message, and optional button, and displays the message along with matching color band and icon.

![dismissablepartitioned](https://user-images.githubusercontent.com/48393093/91316468-d695d900-e786-11ea-951d-2d67327b75fa.png)
![emptytable](https://user-images.githubusercontent.com/48393093/91316470-d72e6f80-e786-11ea-9326-dacaa9749834.png)
