### PR TITLE
[BigQuery] Standardize starter queries

### DIFF
--- a/jupyterlab_bigquery/jupyterlab_bigquery/list_items_handler/service.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/list_items_handler/service.py
@@ -6,6 +6,7 @@ from google.cloud import bigquery
 from google.cloud.datacatalog import DataCatalogClient, types
 
 SCOPE = ("https://www.googleapis.com/auth/cloud-platform",)
+MODEL = 'MODEL'
 
 
 class BigQueryService:
@@ -89,7 +90,7 @@ class BigQueryService:
           'id': model_full_id,
           'name': model.model_id,
           'datasetId': dataset_id,
-          'type': 'MODEL'
+          'type': MODEL
       }
       model_ids.append(model_full_id)
 

--- a/jupyterlab_bigquery/jupyterlab_bigquery/list_items_handler/service.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/list_items_handler/service.py
@@ -89,6 +89,7 @@ class BigQueryService:
           'id': model_full_id,
           'name': model.model_id,
           'datasetId': dataset_id,
+          'type': 'MODEL'
       }
       model_ids.append(model_full_id)
 

--- a/jupyterlab_bigquery/src/components/details_panel/model_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/model_details_panel.tsx
@@ -15,6 +15,7 @@ import { WidgetManager } from '../../utils/widgetManager/widget_manager';
 import { generateQueryId } from '../../reducers/queryEditorTabSlice';
 import { localStyles } from './dataset_details_panel';
 import { formatDate } from '../../utils/formatters';
+import { getStarterQuery } from '../../utils/starter_queries';
 
 interface Props {
   modelDetailsService: ModelDetailsService;
@@ -208,10 +209,7 @@ export default class ModelDetailsPanel extends React.Component<Props, State> {
                   'main',
                   queryId,
                   undefined,
-                  [
-                    queryId,
-                    `SELECT * FROM ML.PREDICT(MODEL \`${this.props.modelId}\`, )`,
-                  ]
+                  [queryId, getStarterQuery('MODEL', this.props.modelId)]
                 );
               }}
               startIcon={<Code />}

--- a/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Button } from '@material-ui/core';
 import { Code, Info } from '@material-ui/icons';
+import { stylesheet } from 'typestyle';
 
 import {
   TableDetailsService,
@@ -14,7 +15,7 @@ import TablePreviewPanel from './table_preview';
 import { QueryEditorTabWidget } from '../query_editor/query_editor_tab/query_editor_tab_widget';
 import { WidgetManager } from '../../utils/widgetManager/widget_manager';
 import { generateQueryId } from '../../reducers/queryEditorTabSlice';
-import { stylesheet } from 'typestyle';
+import { getStarterQuery } from '../../utils/starter_queries';
 import { BASE_FONT } from 'gcp_jupyterlab_shared';
 import InfoCard from '../shared/info_card';
 
@@ -96,10 +97,7 @@ export default class TableDetailsTabs extends React.Component<Props, State> {
                   'main',
                   queryId,
                   undefined,
-                  [
-                    queryId,
-                    `SELECT * FROM \`${this.props.table_id}\` LIMIT 1000`,
-                  ]
+                  [queryId, getStarterQuery('TABLE', this.props.table_id)]
                 );
               }}
               startIcon={<Code />}

--- a/jupyterlab_bigquery/src/components/details_panel/view_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/view_details_panel.tsx
@@ -11,6 +11,7 @@ import { WidgetManager } from '../../utils/widgetManager/widget_manager';
 import { generateQueryId } from '../../reducers/queryEditorTabSlice';
 import { localStyles } from './dataset_details_panel';
 import { formatDate } from '../../utils/formatters';
+import { getStarterQuery } from '../../utils/starter_queries';
 
 interface Props {
   viewDetailsService: ViewDetailsService;
@@ -96,10 +97,7 @@ export default class ViewDetailsPanel extends React.Component<Props, State> {
                   'main',
                   queryId,
                   undefined,
-                  [
-                    queryId,
-                    `SELECT * FROM \`${this.props.view_id}\` LIMIT 1000`,
-                  ]
+                  [queryId, getStarterQuery('VIEW', this.props.view_id)]
                 );
               }}
               startIcon={<Code />}

--- a/jupyterlab_bigquery/src/utils/starter_queries.ts
+++ b/jupyterlab_bigquery/src/utils/starter_queries.ts
@@ -1,0 +1,11 @@
+export function getStarterQuery(
+  type: 'MODEL' | 'TABLE' | 'VIEW',
+  resourceId: string
+) {
+  console.log('type: ', type);
+  if (type === 'MODEL') {
+    return `SELECT * FROM ML.PREDICT(MODEL \`${resourceId}\`, )`;
+  } else {
+    return `SELECT * FROM \`${resourceId}\` LIMIT 1000`;
+  }
+}

--- a/jupyterlab_bigquery/src/utils/starter_queries.ts
+++ b/jupyterlab_bigquery/src/utils/starter_queries.ts
@@ -1,8 +1,6 @@
-export function getStarterQuery(
-  type: 'MODEL' | 'TABLE' | 'VIEW',
-  resourceId: string
-) {
-  console.log('type: ', type);
+type QueryType = 'MODEL' | 'TABLE' | 'VIEW';
+
+export function getStarterQuery(type: QueryType, resourceId: string) {
   if (type === 'MODEL') {
     return `SELECT * FROM ML.PREDICT(MODEL \`${resourceId}\`, )`;
   } else {


### PR DESCRIPTION
Makes boilerplate query through context menu available for all resources (previously unavailable for models and views), centralizes starter query text to the utils folder.