### PR TITLE
[BigQuery] Fix timezone issue with fromtimestamp

### DIFF
--- a/jupyterlab_bigquery/jupyterlab_bigquery/details_handler/service.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/details_handler/service.py
@@ -314,7 +314,7 @@ class BigQueryService:
             } for feat_col in model.feature_columns],
             'training_runs': [
                 format_date(
-                    datetime.datetime.fromtimestamp(run.start_time.seconds))
+                    datetime.datetime.fromtimestamp(run.start_time.seconds, datetime.timezone.utc))
                 for run in model.training_runs
             ]
         }

--- a/jupyterlab_bigquery/jupyterlab_bigquery/tests/details_service_test.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/tests/details_service_test.py
@@ -694,7 +694,7 @@ class TestModelDetails(unittest.TestCase):
                 'name': 'feature_col_0',
                 'type': SqlTypeNames[StandardSqlDataTypes(8).name].name
             }],
-            'training_runs': ['1970-01-15T01:56:07', '1970-01-15T01:59:49']
+            'training_runs': ['1970-01-15T06:56:07+00:00', '1970-01-15T06:59:49+00:00']
         }
     }
 
@@ -755,7 +755,7 @@ class TestModelDetails(unittest.TestCase):
             'model_type': Model.ModelType(0).name,
             'schema_labels': [],
             'feature_columns': [],
-            'training_runs': ['1970-01-15T01:56:07']
+            'training_runs': ['1970-01-15T06:56:07+00:00']
         }
     }
 


### PR DESCRIPTION
Adds a UTC timezone to `fromtimestamp`, which I didn't realize actually converts to local timezone by default rather than UTC. This will correct the training runs dropdown select dates.