### PR TITLE
[HardwareConfiguration] Moving service initialization to root

### DIFF
--- a/jupyterlab_gcedetails/src/components/server_wrapper.tsx
+++ b/jupyterlab_gcedetails/src/components/server_wrapper.tsx
@@ -5,11 +5,10 @@ export class ServerWrapper {
   private readonly serverSettings: ServerConnection.ISettings;
   private readonly url: string;
   constructor(
-    endpoint: string,
     serverSettings: ServerConnection.ISettings = ServerConnection.defaultSettings
   ) {
     this.serverSettings = serverSettings;
-    this.url = this.serverSettings.baseUrl + endpoint;
+    this.url = this.serverSettings.baseUrl + `gcp/v1/details`;
   }
 
   async getUtilizationData(): Promise<Details> {

--- a/jupyterlab_gcedetails/src/index.ts
+++ b/jupyterlab_gcedetails/src/index.ts
@@ -42,8 +42,7 @@ async function activateDetailsWidget(
 
   const clientTransportService = new ClientTransportService();
   const serverProxyTransportService = new ServerProxyTransportService();
-  const detailsUrl = `gcp/v1/details`;
-  const detailsServer = new ServerWrapper(detailsUrl);
+  const detailsServer = new ServerWrapper();
 
   let notebooksService: NotebooksService;
   let detailsService: DetailsService;

--- a/jupyterlab_gcedetails/src/index.ts
+++ b/jupyterlab_gcedetails/src/index.ts
@@ -23,19 +23,72 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin,
 } from '@jupyterlab/application';
+import {
+  getMetadata,
+  ClientTransportService,
+  ServerProxyTransportService,
+} from 'gcp_jupyterlab_shared';
+import { NotebooksService } from './service/notebooks_service';
+import { extractLast } from './data/data';
+import { DetailsService } from './service/details_service';
+import { PriceService } from './service/price_service';
+import { ServerWrapper } from './components/server_wrapper';
+
+async function activateDetailsWidget(
+  app: JupyterFrontEnd,
+  statusbar: IStatusBar
+) {
+  console.debug('Activating GCP Details Extension');
+
+  const clientTransportService = new ClientTransportService();
+  const serverProxyTransportService = new ServerProxyTransportService();
+  const detailsUrl = `gcp/v1/details`;
+  const detailsServer = new ServerWrapper(detailsUrl);
+
+  let notebooksService: NotebooksService;
+  let detailsService: DetailsService;
+  let priceService: PriceService;
+  let initializationError = false;
+
+  try {
+    const details = await getMetadata();
+
+    notebooksService = new NotebooksService(
+      clientTransportService,
+      details.project,
+      extractLast(details.name),
+      extractLast(details.zone)
+    );
+    detailsService = new DetailsService(
+      serverProxyTransportService,
+      details.project,
+      extractLast(details.zone)
+    );
+    priceService = new PriceService();
+  } catch (err) {
+    initializationError = true;
+  }
+
+  const detailsWidget = new VmDetailsWidget(
+    detailsServer,
+    notebooksService,
+    detailsService,
+    priceService,
+    initializationError
+  );
+
+  statusbar.registerStatusItem('gceDetails', {
+    item: detailsWidget,
+    align: 'left',
+  });
+}
 
 // Default export for the front-end plugin providing GCE details.
 const gceDetails: JupyterFrontEndPlugin<void> = {
   id: 'jupyterlab_gcedetails',
   requires: [IStatusBar],
   autoStart: true,
-  activate: (_: JupyterFrontEnd, statusbar: IStatusBar) => {
-    const detailsWidget = new VmDetailsWidget();
-    statusbar.registerStatusItem('gceDetails', {
-      item: detailsWidget,
-      align: 'left',
-    });
-  },
+  activate: activateDetailsWidget,
 };
 
 export default gceDetails;


### PR DESCRIPTION
Currently service initialization happens after the first call to get details from the server as the project name, location, and instance name is needed to set up the services. Moving this to the root index file following the gcp_scheduler widget initialization pattern. If the getMetadata call fails then the error status is passed as props and the widget is launched in an error state.