### PR TITLE
[HardwareConfiguration] Making details a required prop past the details page in the configura…

### DIFF
--- a/jupyterlab_gcedetails/src/components/__snapshots__/hardware_scaling_status.spec.tsx.snap
+++ b/jupyterlab_gcedetails/src/components/__snapshots__/hardware_scaling_status.spec.tsx.snap
@@ -4,6 +4,22 @@ exports[`HardwareScalingStatus Renders with auth error: Auth Error 1`] = `
 <ErrorPage
   error={null}
   instanceDetails={null}
+  machineTypes={
+    Array [
+      Object {
+        "base": Object {
+          "text": "Efficient Instance",
+          "value": "e2-",
+        },
+        "configurations": Array [
+          Object {
+            "text": "Efficient Instance, 8 vCPUs, 64 GB RAM",
+            "value": "e2-highmem-8",
+          },
+        ],
+      },
+    ]
+  }
   onDialogClose={[MockFunction]}
 />
 `;
@@ -26,6 +42,22 @@ exports[`HardwareScalingStatus Renders with operation error: Operation error 1`]
       "name": "Test",
     }
   }
+  machineTypes={
+    Array [
+      Object {
+        "base": Object {
+          "text": "Efficient Instance",
+          "value": "e2-",
+        },
+        "configurations": Array [
+          Object {
+            "text": "Efficient Instance, 8 vCPUs, 64 GB RAM",
+            "value": "e2-highmem-8",
+          },
+        ],
+      },
+    ]
+  }
   onDialogClose={[MockFunction]}
 />
 `;
@@ -37,6 +69,22 @@ exports[`HardwareScalingStatus Renders with restart error: Restart error 1`] = `
       "errorType": "Start",
       "errorValue": Promise {},
     }
+  }
+  machineTypes={
+    Array [
+      Object {
+        "base": Object {
+          "text": "Efficient Instance",
+          "value": "e2-",
+        },
+        "configurations": Array [
+          Object {
+            "text": "Efficient Instance, 8 vCPUs, 64 GB RAM",
+            "value": "e2-highmem-8",
+          },
+        ],
+      },
+    ]
   }
   onDialogClose={[MockFunction]}
 />
@@ -51,6 +99,22 @@ exports[`HardwareScalingStatus Renders with stop error: Stop instance error 1`] 
     }
   }
   instanceDetails={null}
+  machineTypes={
+    Array [
+      Object {
+        "base": Object {
+          "text": "Efficient Instance",
+          "value": "e2-",
+        },
+        "configurations": Array [
+          Object {
+            "text": "Efficient Instance, 8 vCPUs, 64 GB RAM",
+            "value": "e2-highmem-8",
+          },
+        ],
+      },
+    ]
+  }
   onDialogClose={[MockFunction]}
 />
 `;

--- a/jupyterlab_gcedetails/src/components/confirmation_page.tsx
+++ b/jupyterlab_gcedetails/src/components/confirmation_page.tsx
@@ -25,7 +25,7 @@ import { ActionBar } from './action_bar';
 interface Props {
   formData: HardwareConfiguration;
   onDialogClose: () => void;
-  currentConfiguration?: HardwareConfiguration;
+  currentConfiguration: HardwareConfiguration;
   onSubmit: () => void;
 }
 
@@ -61,8 +61,7 @@ export function ConfirmationPage(props: Props) {
       <div className={STYLES.containerSize}>
         <span className={STYLES.heading}>Hardware Scaling Limits</span>
         <HardwareConfigurationDescription />
-        {currentConfiguration &&
-          displayConfiguration(currentConfiguration, 'Old Configuration')}
+        {displayConfiguration(currentConfiguration, 'Old Configuration')}
         {displayConfiguration(formData, 'New Configuration')}
         <div className={STYLES.infoMessage}>
           <Message asError={false} asActivity={false} text={INFO_MESSAGE} />

--- a/jupyterlab_gcedetails/src/components/error_page.tsx
+++ b/jupyterlab_gcedetails/src/components/error_page.tsx
@@ -26,7 +26,7 @@ import { displayInstance } from './instance_details_message';
 
 interface Props {
   instanceDetails?: Instance;
-  machineTypes?: MachineTypeConfiguration[];
+  machineTypes: MachineTypeConfiguration[];
   error: ConfigurationError;
   onDialogClose: () => void;
 }

--- a/jupyterlab_gcedetails/src/components/hardware_configuration_dialog.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_configuration_dialog.tsx
@@ -94,6 +94,7 @@ export class HardwareConfigurationDialog extends React.Component<Props, State> {
             receivedError={receivedError}
           />
         );
+
       case View.FORM:
         return (
           <HardwareScalingForm
@@ -114,9 +115,7 @@ export class HardwareConfigurationDialog extends React.Component<Props, State> {
           <ConfirmationPage
             onDialogClose={onClose}
             formData={hardwareConfiguration}
-            currentConfiguration={
-              details && detailsToHardwareConfiguration(details)
-            }
+            currentConfiguration={detailsToHardwareConfiguration(details)}
             onSubmit={() => {
               this.setState({
                 view: View.STATUS,
@@ -134,7 +133,7 @@ export class HardwareConfigurationDialog extends React.Component<Props, State> {
             onCompletion={onCompletion}
             detailsServer={detailsServer}
             authTokenRetrieval={authTokenRetrieval}
-            machineTypes={details && details.machineTypes}
+            machineTypes={details.machineTypes}
           />
         );
     }

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
@@ -35,15 +35,12 @@ import {
   extractLast,
 } from '../data/data';
 import {
-  ACCELERATOR_COUNTS_1_2_4_8,
-  ACCELERATOR_TYPES,
   getGpuTypeOptionsList,
   getGpuCountOptionsList,
   NO_ACCELERATOR_TYPE,
   NO_ACCELERATOR_COUNT,
 } from '../data/accelerator_types';
 import {
-  MACHINE_TYPES,
   optionToMachineType,
   machineTypeToOption,
   MachineTypeConfiguration,
@@ -54,7 +51,7 @@ import { PriceService } from '../service/price_service';
 interface Props {
   onSubmit: (configuration: HardwareConfiguration) => void;
   onDialogClose: () => void;
-  details?: Details;
+  details: Details;
   priceService: PriceService;
 }
 
@@ -80,9 +77,6 @@ export const FORM_STYLES = stylesheet({
 });
 
 const N1_MACHINE_PREFIX = 'n1-';
-const DEFAULT_MACHINE_TYPE = optionToMachineType(
-  MACHINE_TYPES[0].configurations[0]
-);
 const GPU_RESTRICTION_MESSAGE = `Based on the zone, framework, and machine type of the instance, 
 the available GPU types and the minimum number of GPUs that can be selected may vary. `;
 const GPU_RESTRICTION_LINK = 'https://cloud.google.com/compute/docs/gpus';
@@ -98,39 +92,23 @@ export class HardwareScalingForm extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    this.oldConfiguration = props.details
-      ? detailsToHardwareConfiguration(props.details)
-      : null;
+    this.oldConfiguration = detailsToHardwareConfiguration(props.details);
 
     this.state = {
-      configuration: this.oldConfiguration
-        ? this.oldConfiguration
-        : {
-            machineType: DEFAULT_MACHINE_TYPE,
-            attachGpu: false,
-            gpuType: NO_ACCELERATOR_TYPE,
-            gpuCount: NO_ACCELERATOR_COUNT,
-          },
+      configuration: this.oldConfiguration,
       // update the gpu count options based on the selected gpu type
-      gpuCountOptions: props.details
-        ? getGpuCountOptionsList(
-            props.details.acceleratorTypes,
-            props.details.gpu.name
-          )
-        : ACCELERATOR_COUNTS_1_2_4_8,
+      gpuCountOptions: getGpuCountOptionsList(
+        props.details.acceleratorTypes,
+        props.details.gpu.name
+      ),
       newConfigurationPrice: undefined,
     };
 
-    this.gpuTypeOptions = props.details
-      ? getGpuTypeOptionsList(
-          props.details.acceleratorTypes,
-          props.details.instance.cpuPlatform
-        )
-      : ACCELERATOR_TYPES;
-
-    this.machineTypesOptions = props.details
-      ? props.details.machineTypes
-      : MACHINE_TYPES;
+    this.gpuTypeOptions = getGpuTypeOptionsList(
+      props.details.acceleratorTypes,
+      props.details.instance.cpuPlatform
+    );
+    this.machineTypesOptions = props.details.machineTypes;
 
     this.getOldConfigurationPrice();
   }

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_status.spec.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_status.spec.tsx
@@ -6,6 +6,7 @@ import { DETAILS_RESPONSE } from '../test_helpers';
 import { NotebooksService, Instance } from '../service/notebooks_service';
 import { ServerWrapper } from './server_wrapper';
 import { detailsToHardwareConfiguration } from '../data/data';
+import { MachineTypeConfiguration } from '../data/machine_types';
 
 function immediatePromise() {
   return new Promise(r => setTimeout(r));
@@ -41,7 +42,17 @@ describe('HardwareScalingStatus', () => {
     },
   };
   const mockToken = 'mockToken';
-
+  const mockMachineTypes: MachineTypeConfiguration[] = [
+    {
+      base: { value: 'e2-', text: 'Efficient Instance' },
+      configurations: [
+        {
+          value: 'e2-highmem-8',
+          text: 'Efficient Instance, 8 vCPUs, 64 GB RAM',
+        },
+      ],
+    },
+  ];
   beforeEach(() => {
     jest.resetAllMocks();
   });
@@ -64,6 +75,7 @@ describe('HardwareScalingStatus', () => {
         onDialogClose={mockOnDialogClose}
         hardwareConfiguration={hardwareConfig}
         authTokenRetrieval={mockAuthTokenRetrieval}
+        machineTypes={mockMachineTypes}
       />
     );
     expect(hardwareScalingStatus.state('status')).toEqual(Status.Authorizing);
@@ -123,6 +135,7 @@ describe('HardwareScalingStatus', () => {
         onDialogClose={mockOnDialogClose}
         hardwareConfiguration={hardwareConfig}
         authTokenRetrieval={mockAuthTokenRetrieval}
+        machineTypes={mockMachineTypes}
       />
     );
     await rejectedAuth.catch(() => {});
@@ -144,6 +157,7 @@ describe('HardwareScalingStatus', () => {
         onDialogClose={mockOnDialogClose}
         hardwareConfiguration={hardwareConfig}
         authTokenRetrieval={mockAuthTokenRetrieval}
+        machineTypes={mockMachineTypes}
       />
     );
     await mockAuthTokenRetrieval();
@@ -172,6 +186,7 @@ describe('HardwareScalingStatus', () => {
         onDialogClose={mockOnDialogClose}
         hardwareConfiguration={hardwareConfig}
         authTokenRetrieval={mockAuthTokenRetrieval}
+        machineTypes={mockMachineTypes}
       />
     );
     await mockAuthTokenRetrieval();
@@ -205,6 +220,7 @@ describe('HardwareScalingStatus', () => {
         onDialogClose={mockOnDialogClose}
         hardwareConfiguration={hardwareConfig}
         authTokenRetrieval={mockAuthTokenRetrieval}
+        machineTypes={mockMachineTypes}
       />
     );
     await mockAuthTokenRetrieval();

--- a/jupyterlab_gcedetails/src/components/hardware_scaling_status.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_status.tsx
@@ -96,7 +96,7 @@ interface Props {
   onCompletion: () => void;
   detailsServer: ServerWrapper;
   authTokenRetrieval: () => Promise<string>;
-  machineTypes?: MachineTypeConfiguration[];
+  machineTypes: MachineTypeConfiguration[];
 }
 
 interface State {

--- a/jupyterlab_gcedetails/src/data/accelerator_types.ts
+++ b/jupyterlab_gcedetails/src/data/accelerator_types.ts
@@ -127,7 +127,11 @@ export function getGpuCountOptionsList(
   accelerators: Accelerator[],
   acceleratorName: string
 ): Option[] {
-  if (!acceleratorName || acceleratorName === NO_ACCELERATOR_TYPE)
+  if (
+    !acceleratorName ||
+    acceleratorName === NO_ACCELERATOR_TYPE ||
+    !accelerators
+  )
     return ACCELERATOR_COUNTS_1_2_4_8;
 
   const accelerator = accelerators.find(


### PR DESCRIPTION
…tion dialog

As of https://github.com/GoogleCloudPlatform/jupyter-extensions/pull/258 if details can't be retrieved the user will not be able to navigate past the details page in the hardware configuration dialog - this PR makes details a required prop for any component that has details as an optional prop and is rendered after the details page.