### PR TITLE
[BigQuery] Dark mode

### DIFF
--- a/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
@@ -15,7 +15,7 @@ export const localStyles = stylesheet({
     marginBottom: '10px',
   },
   panel: {
-    backgroundColor: 'white',
+    backgroundColor: 'var(--jp-layout-color0)',
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
@@ -45,12 +45,24 @@ export const localStyles = stylesheet({
   },
 });
 
+interface ChipProps {
+  darkMode: boolean;
+  size?: 'medium' | 'small';
+  component?: any;
+  key?: string | number;
+  label: string;
+}
+
 const StyledChip = withStyles({
   root: {
-    color: '#1967D2',
-    backgroundColor: 'rgba(25, 103, 210, 0.1)',
+    color: (props: ChipProps) =>
+      // white :  blue600
+      props.darkMode ? 'var(--jp-ui-font-color1)' : '#1A73E8',
+    backgroundColor: (props: ChipProps) =>
+      // blue300 at 30% opacity : blue600 at 10% opacity
+      props.darkMode ? 'rgba(138, 180, 248, 0.3)' : 'rgba(26, 115, 232, 0.1)',
   },
-})(Chip);
+})((props: ChipProps) => <Chip {...props} />);
 
 interface SharedDetails {
   id: string;
@@ -103,7 +115,15 @@ export const DetailsPanel: React.SFC<Props> = props => {
                 <div className={localStyles.labelContainer}>
                   {details.labels.map((value, index) => {
                     return (
-                      <StyledChip size="small" key={index} label={value} />
+                      <StyledChip
+                        size="small"
+                        key={index}
+                        label={value}
+                        darkMode={
+                          document.body.getAttribute('data-jp-theme-light') ===
+                          'false'
+                        }
+                      />
                     );
                   })}
                 </div>

--- a/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/details_panel.tsx
@@ -8,6 +8,7 @@ import { SchemaField } from './service/list_table_details';
 import { ModelSchema } from './service/list_model_details';
 import { StripedRows } from '../shared/striped_rows';
 import { SchemaTable, ModelSchemaTable } from '../shared/schema_table';
+import { isDarkTheme } from '../../utils/dark_theme';
 
 export const localStyles = stylesheet({
   title: {
@@ -46,7 +47,7 @@ export const localStyles = stylesheet({
 });
 
 interface ChipProps {
-  darkMode: boolean;
+  darkmode: boolean;
   size?: 'medium' | 'small';
   component?: any;
   key?: string | number;
@@ -57,10 +58,10 @@ const StyledChip = withStyles({
   root: {
     color: (props: ChipProps) =>
       // white :  blue600
-      props.darkMode ? 'var(--jp-ui-font-color1)' : '#1A73E8',
+      props.darkmode ? 'var(--jp-ui-font-color1)' : '#1A73E8',
     backgroundColor: (props: ChipProps) =>
       // blue300 at 30% opacity : blue600 at 10% opacity
-      props.darkMode ? 'rgba(138, 180, 248, 0.3)' : 'rgba(26, 115, 232, 0.1)',
+      props.darkmode ? 'rgba(138, 180, 248, 0.3)' : 'rgba(26, 115, 232, 0.1)',
   },
 })((props: ChipProps) => <Chip {...props} />);
 
@@ -119,10 +120,7 @@ export const DetailsPanel: React.SFC<Props> = props => {
                         size="small"
                         key={index}
                         label={value}
-                        darkMode={
-                          document.body.getAttribute('data-jp-theme-light') ===
-                          'false'
-                        }
+                        darkmode={isDarkTheme()}
                       />
                     );
                   })}

--- a/jupyterlab_bigquery/src/components/details_panel/model_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/model_details_panel.tsx
@@ -16,6 +16,7 @@ import { generateQueryId } from '../../reducers/queryEditorTabSlice';
 import { localStyles } from './dataset_details_panel';
 import { formatDate } from '../../utils/formatters';
 import { getStarterQuery } from '../../utils/starter_queries';
+import { gColor } from '../shared/styles';
 
 interface Props {
   modelDetailsService: ModelDetailsService;
@@ -66,10 +67,32 @@ const displayOptionNames = {
 };
 
 const StyledMenuItem = withStyles({
-  selected: {
-    color: '#1A73E8',
+  root: {
+    color: 'var(--jp-ui-font-color1)',
+    backgroundColor: 'var(--jp-layout-color0)',
+    '&$selected': {
+      backgroundColor: 'var(--jp-layout-color2)',
+      '&:hover': {
+        backgroundColor: 'var(--jp-layout-color2)',
+      },
+    },
+    '&:hover': {
+      backgroundColor: 'var(--jp-layout-color2)',
+    },
   },
+  selected: {},
 })(MenuItem);
+
+// TODO: style for dark mode. Currently the container is still constant white.
+const StyledSelect = withStyles({
+  root: {
+    marginLeft: '36px',
+    color: 'var(--jp-ui-font-color1)',
+  },
+  icon: {
+    color: 'var(--jp-ui-font-color1)',
+  },
+})(Select);
 
 export default class ModelDetailsPanel extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -174,14 +197,13 @@ export default class ModelDetailsPanel extends React.Component<Props, State> {
               {this.props.modelName}
               {this.state.details.details.training_runs &&
               this.state.details.details.training_runs.length > 1 ? (
-                <Select
+                <StyledSelect
                   value={this.state.currentRun}
                   onChange={event => {
                     this.setState({ currentRun: event.target.value as number });
                     this.getTrainingRunDetails(event.target.value as number);
                   }}
                   disableUnderline
-                  style={{ marginLeft: '36px' }}
                 >
                   {this.state.details.details.training_runs &&
                     this.state.details.details.training_runs.map(
@@ -196,7 +218,7 @@ export default class ModelDetailsPanel extends React.Component<Props, State> {
                         );
                       }
                     )}
-                </Select>
+                </StyledSelect>
               ) : (
                 undefined
               )}
@@ -213,7 +235,10 @@ export default class ModelDetailsPanel extends React.Component<Props, State> {
                 );
               }}
               startIcon={<Code />}
-              style={{ textTransform: 'none', color: '#1A73E8' }}
+              style={{
+                textTransform: 'none',
+                color: gColor('BLUE'),
+              }}
             >
               Query model
             </Button>

--- a/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_details_tabs.tsx
@@ -16,6 +16,7 @@ import { QueryEditorTabWidget } from '../query_editor/query_editor_tab/query_edi
 import { WidgetManager } from '../../utils/widgetManager/widget_manager';
 import { generateQueryId } from '../../reducers/queryEditorTabSlice';
 import { getStarterQuery } from '../../utils/starter_queries';
+import { gColor } from '../shared/styles';
 import { BASE_FONT } from 'gcp_jupyterlab_shared';
 import InfoCard from '../shared/info_card';
 
@@ -101,7 +102,10 @@ export default class TableDetailsTabs extends React.Component<Props, State> {
                 );
               }}
               startIcon={<Code />}
-              style={{ textTransform: 'none', color: '#1A73E8' }}
+              style={{
+                textTransform: 'none',
+                color: gColor('BLUE'),
+              }}
             >
               Query table
             </Button>
@@ -126,7 +130,10 @@ export default class TableDetailsTabs extends React.Component<Props, State> {
                 button={
                   <Button
                     size="small"
-                    style={{ textTransform: 'none' }}
+                    style={{
+                      textTransform: 'none',
+                      color: 'var(--jp-ui-font-color1)',
+                    }}
                     onClick={() => {
                       this.setState({ showPartitionCard: false });
                     }}
@@ -139,9 +146,10 @@ export default class TableDetailsTabs extends React.Component<Props, State> {
             <StyledTabs
               value={this.state.currentTab}
               onChange={this.handleChange.bind(this)}
+              color={gColor('BLUE')}
             >
-              <StyledTab label="Details" />
-              <StyledTab label="Preview" />
+              <StyledTab label="Details" color={gColor('BLUE')} />
+              <StyledTab label="Preview" color={gColor('BLUE')} />
             </StyledTabs>
             <TabPanel
               value={this.state.currentTab}

--- a/jupyterlab_bigquery/src/components/details_panel/table_preview.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/table_preview.tsx
@@ -9,6 +9,7 @@ import {
 } from './service/list_table_details';
 import { BQTable } from '../shared/bq_table';
 import InfoCard from '../shared/info_card';
+import { gColor } from '../shared/styles';
 
 const localStyles = stylesheet({
   previewBody: {
@@ -93,7 +94,7 @@ export default class TablePreviewPanel extends React.Component<Props, State> {
           ) : (
             <div className={localStyles.previewBody}>
               <InfoCard
-                color="#FBBC04"
+                color={gColor('YELLOW')}
                 message="This table is empty."
                 icon={<Warning />}
               />

--- a/jupyterlab_bigquery/src/components/details_panel/view_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/view_details_panel.tsx
@@ -12,6 +12,7 @@ import { generateQueryId } from '../../reducers/queryEditorTabSlice';
 import { localStyles } from './dataset_details_panel';
 import { formatDate } from '../../utils/formatters';
 import { getStarterQuery } from '../../utils/starter_queries';
+import { gColor } from '../shared/styles';
 
 interface Props {
   viewDetailsService: ViewDetailsService;
@@ -101,7 +102,10 @@ export default class ViewDetailsPanel extends React.Component<Props, State> {
                 );
               }}
               startIcon={<Code />}
-              style={{ textTransform: 'none', color: '#1A73E8' }}
+              style={{
+                textTransform: 'none',
+                color: gColor('BLUE'),
+              }}
             >
               Query view
             </Button>

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
@@ -31,8 +31,7 @@ import { ViewDetailsService } from '../details_panel/service/list_view_details';
 import { ModelDetailsWidget } from '../details_panel/model_details_widget';
 import { ModelDetailsService } from '../details_panel/service/list_model_details';
 import { getStarterQuery } from '../../utils/starter_queries';
-
-import '../../../style/index.css';
+import { gColor } from '../shared/styles';
 
 import { ContextMenu } from 'gcp_jupyterlab_shared';
 
@@ -75,7 +74,6 @@ const localStyles = stylesheet({
   resourceIcons: {
     display: 'flex',
     alignContent: 'center',
-    color: 'var(--jp-layout-color3)',
   },
   datasetName: {
     flexDirection: 'row',
@@ -440,7 +438,7 @@ export class DatasetResource extends Resource<DatasetProps> {
               }))}
             >
               <div className={localStyles.datasetName}>
-                <Icon style={{ display: 'flex', alignContent: 'center' }}>
+                <Icon className={localStyles.resourceIcons}>
                   <div className={'jp-Icon jp-Icon-20 jp-DatasetIcon'} />
                 </Icon>
                 <div className={localStyles.resourceName}>{dataset.name}</div>
@@ -476,6 +474,7 @@ export class DatasetResource extends Resource<DatasetProps> {
             <CircularProgress
               size={20}
               className={localStyles.circularProgress}
+              style={{ color: gColor('BLUE') }}
             />
           )}
         </TreeItem>
@@ -622,6 +621,7 @@ export class ProjectResource extends Resource<ProjectProps> {
             <CircularProgress
               size={20}
               className={localStyles.circularProgress}
+              style={{ color: gColor('BLUE') }}
             />
           )}
         </TreeItem>

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
@@ -39,7 +39,8 @@ import {
   SearchResult,
 } from '../list_items_panel/service/search_items';
 import { SearchBar } from './search_bar';
-import { DialogComponent, COLORS, BASE_FONT } from 'gcp_jupyterlab_shared';
+import { gColor } from '../shared/styles';
+import { DialogComponent, BASE_FONT } from 'gcp_jupyterlab_shared';
 import CustomSnackbar from './snackbar';
 
 interface Props {
@@ -169,13 +170,13 @@ const localStyles = stylesheet({
     zIndex: 1,
     gridColumnStart: 1,
     gridRowStart: 1,
-    backgroundColor: 'white',
+    backgroundColor: 'var(--jp-layout-color1)',
     margin: 0,
     padding: 0,
     ...csstips.flex,
   },
   panel: {
-    backgroundColor: 'white',
+    backgroundColor: 'var(--jp-layout-color1)',
     height: '100%',
     ...BASE_FONT,
     ...csstips.vertical,
@@ -192,7 +193,10 @@ const localStyles = stylesheet({
     margin: 0,
     padding: '10px 14px',
     '&:hover': {
-      backgroundColor: '#e8e8e8',
+      backgroundColor:
+        document.body.getAttribute('data-jp-theme-light') === 'true'
+          ? '#e8e8e8'
+          : 'var(--jp-layout-color2)',
       opacity: 1,
       cursor: 'pointer',
     },
@@ -379,7 +383,6 @@ class ListItemsPanel extends React.Component<Props, State> {
           <div className={localStyles.buttonContainer}>
             <Tooltip title="Open SQL editor">
               <Button
-                style={{ color: COLORS.blue }}
                 size="small"
                 variant="outlined"
                 className={localStyles.editQueryButton}
@@ -392,6 +395,10 @@ class ListItemsPanel extends React.Component<Props, State> {
                     undefined,
                     [queryId, undefined]
                   );
+                }}
+                style={{
+                  color: gColor('BLUE'),
+                  border: '1px solid var(--jp-border-color2)',
                 }}
               >
                 <div className={localStyles.buttonLabel}>Open SQL editor</div>

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
@@ -193,10 +193,7 @@ const localStyles = stylesheet({
     margin: 0,
     padding: '10px 14px',
     '&:hover': {
-      backgroundColor:
-        document.body.getAttribute('data-jp-theme-light') === 'true'
-          ? '#e8e8e8'
-          : 'var(--jp-layout-color2)',
+      backgroundColor: 'var(--jp-layout-color2)',
       opacity: 1,
       cursor: 'pointer',
     },

--- a/jupyterlab_bigquery/src/components/list_items_panel/search_bar.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/search_bar.tsx
@@ -17,7 +17,7 @@ const searchStyle = stylesheet({
     borderStyle: 'solid',
     borderRadius: '1px',
     borderWidth: 'thin',
-    borderColor: '#d3d3d3',
+    borderColor: 'var(--jp-border-color2)',
   },
   searchIcon: {
     padding: '2px',
@@ -37,6 +37,8 @@ const searchStyle = stylesheet({
     fontSize: 'var(--jp-ui-font-size1)',
     minWidth: 0,
     textOverflow: 'ellipsis',
+    backgroundColor: 'transparent',
+    color: 'var(--jp-ui-font-color1)',
   },
 });
 

--- a/jupyterlab_bigquery/src/components/loading_panel.tsx
+++ b/jupyterlab_bigquery/src/components/loading_panel.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { CircularProgress } from '@material-ui/core';
 import { stylesheet } from 'typestyle';
+import { gColor } from './shared/styles';
 
 const localStyles = stylesheet({
   container: {
@@ -15,7 +16,7 @@ const localStyles = stylesheet({
 const LoadingPanel = () => {
   return (
     <div className={localStyles.container}>
-      <CircularProgress />
+      <CircularProgress style={{ color: gColor('BLUE') }} />
     </div>
   );
 };

--- a/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab_widget.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab_widget.tsx
@@ -1,14 +1,6 @@
 import QueryEditorTab from './query_editor_tab';
 import * as React from 'react';
-import { stylesheet } from 'typestyle';
 import { ReduxReactWidget } from '../../../utils/widgetManager/redux_react_widget';
-
-const localStyles = stylesheet({
-  panel: {
-    backgroundColor: 'white',
-    height: '100%',
-  },
-});
 
 export class QueryEditorTabWidget extends ReduxReactWidget {
   id = 'query-editor-tab';
@@ -26,13 +18,11 @@ export class QueryEditorTabWidget extends ReduxReactWidget {
 
   renderReact() {
     return (
-      <div className={localStyles.panel}>
-        <QueryEditorTab
-          isVisible={this.isVisible}
-          queryId={this.queryId}
-          iniQuery={this.iniQuery}
-        />
-      </div>
+      <QueryEditorTab
+        isVisible={this.isVisible}
+        queryId={this.queryId}
+        iniQuery={this.iniQuery}
+      />
     );
   }
 }

--- a/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_editor_results.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_editor_results.tsx
@@ -5,6 +5,7 @@ import { QueryResult, QUERY_DATA_TYPE } from './query_text_editor';
 import { QueryId } from '../../../reducers/queryEditorTabSlice';
 import { Header } from '../../shared/header';
 import { BQTable } from '../../shared/bq_table';
+import { gColor } from '../../shared/styles';
 import { Button } from '@material-ui/core';
 import { Equalizer } from '@material-ui/icons';
 import QueryResultsManager from '../../../utils/QueryResultsManager';
@@ -83,7 +84,7 @@ class QueryResults extends Component<QueryResultsProps, QueryResultsState> {
           <Button
             startIcon={<Equalizer fontSize="small" />}
             onClick={this.handleDatastudioExploreButton.bind(this)}
-            style={{ textTransform: 'none', color: '#1A73E8' }}
+            style={{ textTransform: 'none', color: gColor('BLUE') }}
           >
             Explore with Data Studio
           </Button>

--- a/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_text_editor.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_text_editor.tsx
@@ -119,7 +119,10 @@ const styleSheet = stylesheet({
     minHeight: 0,
     display: 'flex',
     flexDirection: 'column',
-    border: '1px solid rgb(218, 220, 224)',
+    border:
+      document.body.getAttribute('data-jp-theme-light') === 'true'
+        ? '1px solid rgb(218, 220, 224)'
+        : '1px solid var(--jp-border-color3)',
   },
   message: {
     display: 'flex',
@@ -130,7 +133,10 @@ const styleSheet = stylesheet({
     marginRight: '0.5rem',
   },
   wholeEditorInCell: {
-    border: '1px solid rgb(218, 220, 224)',
+    border:
+      document.body.getAttribute('data-jp-theme-light') === 'true'
+        ? '1px solid rgb(218, 220, 224)'
+        : '1px solid var(--jp-border-color3)',
   },
   pendingStatus: {
     display: 'flex',
@@ -145,8 +151,17 @@ const styleSheet = stylesheet({
     paddingBottom: '5px',
     paddingLeft: '10px',
     paddingRight: '10px',
-    backgroundColor: 'rgb(248, 249, 250)',
-    borderBottom: '1px solid rgb(218, 220, 224)',
+    backgroundColor:
+      document.body.getAttribute('data-jp-theme-light') === 'true'
+        ? 'rgb(248, 249, 250)'
+        : 'var(--jp-layout-color0)',
+    borderBottom:
+      document.body.getAttribute('data-jp-theme-light') === 'true'
+        ? '1px solid rgb(218, 220, 224)'
+        : '1px solid var(--jp-border-color3)',
+  },
+  icon: {
+    color: 'var(--jp-layout-color3)',
   },
 });
 
@@ -233,12 +248,14 @@ class QueryTextEditor extends React.Component<
 
     monaco.init().then(monacoInstance => {
       this.monacoInstance = monacoInstance;
+      const lightTheme =
+        document.body.getAttribute('data-jp-theme-light') === 'true';
       this.monacoInstance.editor.defineTheme('sqlTheme', {
-        base: 'vs',
+        base: lightTheme ? 'vs' : 'vs-dark',
         inherit: true,
         rules: [],
         colors: {
-          'editorGutter.background': '#f8f9fa',
+          'editorGutter.background': lightTheme ? '#f8f9fa' : '#111111',
         },
       });
     });
@@ -626,7 +643,7 @@ class QueryTextEditor extends React.Component<
           copy(query.trim());
         }}
       >
-        <FileCopyOutlined fontSize="small" />
+        <FileCopyOutlined fontSize="small" className={styleSheet.icon} />
       </IconButton>
     );
   }

--- a/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_text_editor.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_text_editor.tsx
@@ -35,6 +35,7 @@ import { WidgetManager } from '../../../utils/widgetManager/widget_manager';
 import { QueryEditorTabWidget } from '../query_editor_tab/query_editor_tab_widget';
 import { formatBytes } from '../../../utils/formatters';
 import QueryResultsManager from '../../../utils/QueryResultsManager';
+import { isDarkTheme } from '../../../utils/dark_theme';
 
 interface QueryTextEditorState {
   queryState: QueryStates;
@@ -119,10 +120,7 @@ const styleSheet = stylesheet({
     minHeight: 0,
     display: 'flex',
     flexDirection: 'column',
-    border:
-      document.body.getAttribute('data-jp-theme-light') === 'true'
-        ? '1px solid rgb(218, 220, 224)'
-        : '1px solid var(--jp-border-color3)',
+    border: '1px solid var(--jp-border-color2)',
   },
   message: {
     display: 'flex',
@@ -133,10 +131,7 @@ const styleSheet = stylesheet({
     marginRight: '0.5rem',
   },
   wholeEditorInCell: {
-    border:
-      document.body.getAttribute('data-jp-theme-light') === 'true'
-        ? '1px solid rgb(218, 220, 224)'
-        : '1px solid var(--jp-border-color3)',
+    border: '1px solid var(--jp-border-color2)',
   },
   pendingStatus: {
     display: 'flex',
@@ -151,14 +146,8 @@ const styleSheet = stylesheet({
     paddingBottom: '5px',
     paddingLeft: '10px',
     paddingRight: '10px',
-    backgroundColor:
-      document.body.getAttribute('data-jp-theme-light') === 'true'
-        ? 'rgb(248, 249, 250)'
-        : 'var(--jp-layout-color0)',
-    borderBottom:
-      document.body.getAttribute('data-jp-theme-light') === 'true'
-        ? '1px solid rgb(218, 220, 224)'
-        : '1px solid var(--jp-border-color3)',
+    backgroundColor: 'var(--jp-layout-color0)',
+    borderBottom: '1px solid var(--jp-border-color2)',
   },
   icon: {
     color: 'var(--jp-layout-color3)',
@@ -248,14 +237,12 @@ class QueryTextEditor extends React.Component<
 
     monaco.init().then(monacoInstance => {
       this.monacoInstance = monacoInstance;
-      const lightTheme =
-        document.body.getAttribute('data-jp-theme-light') === 'true';
       this.monacoInstance.editor.defineTheme('sqlTheme', {
-        base: lightTheme ? 'vs' : 'vs-dark',
+        base: isDarkTheme() ? 'vs-dark' : 'vs',
         inherit: true,
         rules: [],
         colors: {
-          'editorGutter.background': lightTheme ? '#f8f9fa' : '#111111',
+          'editorGutter.background': isDarkTheme() ? '#111111' : '#f8f9fa',
         },
       });
     });

--- a/jupyterlab_bigquery/src/components/query_history/query_history_widget.tsx
+++ b/jupyterlab_bigquery/src/components/query_history/query_history_widget.tsx
@@ -1,15 +1,7 @@
 import QueryHistoryPanel from './query_history_panel';
 import * as React from 'react';
 import { ReduxReactWidget } from '../../utils/widgetManager/redux_react_widget';
-import { stylesheet } from 'typestyle';
 import { QueryHistoryService } from './service/query_history';
-
-const localStyles = stylesheet({
-  panel: {
-    backgroundColor: 'white',
-    height: '100%',
-  },
-});
 
 export class QueryHistoryWidget extends ReduxReactWidget {
   id = 'query-history-tab';
@@ -22,10 +14,6 @@ export class QueryHistoryWidget extends ReduxReactWidget {
   }
 
   renderReact() {
-    return (
-      <div className={localStyles.panel}>
-        <QueryHistoryPanel queryHistoryService={this.service} />
-      </div>
-    );
+    return <QueryHistoryPanel queryHistoryService={this.service} />;
   }
 }

--- a/jupyterlab_bigquery/src/components/shared/bq_table.tsx
+++ b/jupyterlab_bigquery/src/components/shared/bq_table.tsx
@@ -37,11 +37,10 @@ const localStyles = stylesheet({
   },
 });
 
-// TODO: style for dark mode. Currently the disabled buttons are not visible.
 const StyledIconButton = withStyles({
   root: {
     color: 'var(--jp-ui-font-color1)',
-    '&$disabled': {
+    '&.Mui-disabled': {
       color: 'var(--jp-ui-font-color3)',
     },
   },
@@ -60,7 +59,6 @@ const StyledTableCell = withStyles({
   },
 })(TableCell);
 
-// TODO: style for dark mode. Currently the page selection dropdown when highlighted is unreadable.
 export const StyledPagination: React.ComponentType<any> = withStyles({
   root: {
     backgroundColor: 'var(--jp-layout-color0)',
@@ -74,7 +72,7 @@ export const StyledPagination: React.ComponentType<any> = withStyles({
   menuItem: {
     color: 'var(--jp-ui-font-color1)',
     backgroundColor: 'var(--jp-layout-color0)',
-    '&$selected': {
+    '&.Mui-selected': {
       backgroundColor: 'var(--jp-layout-color2)',
       '&:hover': {
         backgroundColor: 'var(--jp-layout-color2)',

--- a/jupyterlab_bigquery/src/components/shared/bq_table.tsx
+++ b/jupyterlab_bigquery/src/components/shared/bq_table.tsx
@@ -9,6 +9,7 @@ import {
   TableRow,
   TablePagination,
   IconButton,
+  withStyles,
 } from '@material-ui/core';
 import {
   KeyboardArrowLeft,
@@ -17,19 +18,10 @@ import {
   LastPage,
 } from '@material-ui/icons';
 
-import { TableHeadCell } from './schema_table';
+import { TableHeadCell, StyledTableRow } from './schema_table';
+import { BASE_FONT } from 'gcp_jupyterlab_shared';
 
 const localStyles = stylesheet({
-  tableCell: {
-    whiteSpace: 'nowrap',
-    textOverflow: 'ellipsis',
-    overflow: 'hidden',
-    maxWidth: '500px',
-  },
-  pagination: {
-    backgroundColor: 'white',
-    fontSize: '13px',
-  },
   paginationOptions: {
     display: 'flex',
     fontSize: '13px',
@@ -44,6 +36,55 @@ const localStyles = stylesheet({
     color: 'gray',
   },
 });
+
+// TODO: style for dark mode. Currently the disabled buttons are not visible.
+const StyledIconButton = withStyles({
+  root: {
+    color: 'var(--jp-ui-font-color1)',
+    '&$disabled': {
+      color: 'var(--jp-ui-font-color3)',
+    },
+  },
+})(IconButton);
+
+const StyledTableCell = withStyles({
+  root: {
+    color: 'var(--jp-ui-font-color1)',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    maxWidth: '500px',
+    fontSize: '13px',
+    BASE_FONT,
+    border: 0,
+  },
+})(TableCell);
+
+// TODO: style for dark mode. Currently the page selection dropdown when highlighted is unreadable.
+export const StyledPagination: React.ComponentType<any> = withStyles({
+  root: {
+    backgroundColor: 'var(--jp-layout-color0)',
+    color: 'var(--jp-ui-font-color1)',
+    fontSize: '13px',
+    borderTop: 'var(--jp-border-width) solid var(--jp-border-color2)',
+  },
+  selectIcon: {
+    color: 'var(--jp-ui-font-color1)',
+  },
+  menuItem: {
+    color: 'var(--jp-ui-font-color1)',
+    backgroundColor: 'var(--jp-layout-color0)',
+    '&$selected': {
+      backgroundColor: 'var(--jp-layout-color2)',
+      '&:hover': {
+        backgroundColor: 'var(--jp-layout-color2)',
+      },
+    },
+    '&:hover': {
+      backgroundColor: 'var(--jp-layout-color2)',
+    },
+  },
+})(TablePagination);
 
 interface Props {
   rows: (string | number)[][];
@@ -94,24 +135,34 @@ export function TablePaginationActions(props: TablePaginationActionsProps) {
 
   return (
     <div className={localStyles.paginationOptions}>
-      <IconButton onClick={handleFirstPageButtonClick} disabled={page === 0}>
+      <StyledIconButton
+        onClick={handleFirstPageButtonClick}
+        disabled={page === 0}
+        size="small"
+      >
         <FirstPage />
-      </IconButton>
-      <IconButton onClick={handleBackButtonClick} disabled={page === 0}>
+      </StyledIconButton>
+      <StyledIconButton
+        onClick={handleBackButtonClick}
+        disabled={page === 0}
+        size="small"
+      >
         <KeyboardArrowLeft />
-      </IconButton>
-      <IconButton
+      </StyledIconButton>
+      <StyledIconButton
         onClick={handleNextButtonClick}
         disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+        size="small"
       >
         <KeyboardArrowRight />
-      </IconButton>
-      <IconButton
+      </StyledIconButton>
+      <StyledIconButton
         onClick={handleLastPageButtonClick}
         disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+        size="small"
       >
         <LastPage />
-      </IconButton>
+      </StyledIconButton>
     </div>
   );
 }
@@ -144,7 +195,13 @@ export class BQTable extends React.Component<Props, State> {
     return (
       <>
         <div className={localStyles.scrollable}>
-          <Table size="small" style={{ width: 'auto', tableLayout: 'auto' }}>
+          <Table
+            size="small"
+            style={{
+              width: 'auto',
+              tableLayout: 'auto',
+            }}
+          >
             <TableHead>
               <TableRow>
                 {fields.map((field, index) => (
@@ -156,32 +213,32 @@ export class BQTable extends React.Component<Props, State> {
               {rows
                 .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                 .map((row, indexRow) => (
-                  <TableRow key={'table_row_' + indexRow}>
-                    <TableCell>{page * rowsPerPage + indexRow + 1}</TableCell>
+                  <StyledTableRow key={'table_row_' + indexRow}>
+                    <StyledTableCell>
+                      {page * rowsPerPage + indexRow + 1}
+                    </StyledTableCell>
                     {row.map((cell, indexCell) => (
-                      <TableCell
-                        className={localStyles.tableCell}
+                      <StyledTableCell
                         key={'table_row_' + indexRow + '_cell' + indexCell}
                       >
                         {cell ?? <div className={localStyles.null}>null</div>}
-                      </TableCell>
+                      </StyledTableCell>
                     ))}
-                  </TableRow>
+                  </StyledTableRow>
                 ))}
             </TableBody>
           </Table>
         </div>
         {/* TODO(cxjia): hide table pagination when result rows <= 10 */}
-        <TablePagination
-          className={localStyles.pagination}
+        <StyledPagination
           rowsPerPageOptions={[10, 30, 50, 100, 200]}
-          component="div"
           count={rows.length}
           rowsPerPage={rowsPerPage}
           page={page}
           onChangePage={this.handleChangePage.bind(this)}
           onChangeRowsPerPage={this.handleChangeRowsPerPage.bind(this)}
           ActionsComponent={TablePaginationActions}
+          component="div"
         />
       </>
     );

--- a/jupyterlab_bigquery/src/components/shared/info_card.tsx
+++ b/jupyterlab_bigquery/src/components/shared/info_card.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
-import { Paper } from '@material-ui/core';
+import { Paper, withStyles } from '@material-ui/core';
 import { stylesheet } from 'typestyle';
 
 const localStyles = stylesheet({
   container: {
+    root: {
+      backgroundColor: 'var(--jp-layout-color0)',
+    },
     display: 'flex',
     alignItems: 'stretch',
     marginBottom: '12px',
-    backgroundColor: 'var(--jp-layout-color0)',
     justifyContent: 'space-between',
     paddingRight: '12px',
   },
@@ -24,6 +26,19 @@ const localStyles = stylesheet({
   },
 });
 
+const StyledPaper = withStyles({
+  root: {
+    backgroundColor: 'var(--jp-layout-color0)',
+    border: '1px solid var(--jp-border-color2)',
+    color: 'var(--jp-ui-font-color1)',
+    display: 'flex',
+    alignItems: 'stretch',
+    marginBottom: '12px',
+    justifyContent: 'space-between',
+    paddingRight: '12px',
+  },
+})(Paper);
+
 // TODO: figure out type so only material ui icons accepted,
 // and make it work with using .type
 type MaterialUIIcon = any;
@@ -39,7 +54,7 @@ interface InfoCardProps {
 const InfoCard = (props: InfoCardProps) => {
   const { message, color, icon, button } = props;
   return (
-    <Paper className={localStyles.container} variant="outlined">
+    <StyledPaper className={localStyles.container} variant="outlined">
       <div className={localStyles.leftSide}>
         <div style={{ width: '6px', backgroundColor: color }} />
         <div className={localStyles.messageSpace}>
@@ -53,7 +68,7 @@ const InfoCard = (props: InfoCardProps) => {
         </div>
       </div>
       {button}
-    </Paper>
+    </StyledPaper>
   );
 };
 

--- a/jupyterlab_bigquery/src/components/shared/read_only_editor.tsx
+++ b/jupyterlab_bigquery/src/components/shared/read_only_editor.tsx
@@ -20,14 +20,16 @@ function handleEditorDidMount(_, editor) {
       const height = lineCount * lineHeight;
       editorElement.style.height = `${height + 0.5 * lineHeight}px`;
       editor.layout();
+      const lightTheme =
+        document.body.getAttribute('data-jp-theme-light') === 'true';
 
       monaco.editor.defineTheme('viewOnlyQueryTheme', {
-        base: 'vs',
+        base: lightTheme ? 'vs' : 'vs-dark',
         inherit: true,
         rules: [],
         colors: {
-          'editorCursor.foreground': '#FFFFFF',
-          'editorGutter.background': '#f8f9fa',
+          'editorCursor.foreground': lightTheme ? '#FFFFFF' : '#1E1E1E',
+          'editorGutter.background': lightTheme ? '#f8f9fa' : '#111111',
         },
       });
       monaco.editor.setTheme('viewOnlyQueryTheme');
@@ -60,7 +62,10 @@ const READ_ONLY_SQL_EDITOR_OPTIONS: editor.IEditorConstructionOptions = {
 
 const ReadOnlyEditor = props => {
   return (
-    <Paper variant="outlined">
+    <Paper
+      variant="outlined"
+      style={{ border: '1px solid var(--jp-border-color2)' }}
+    >
       <Editor
         width="100%"
         theme={'vs'}

--- a/jupyterlab_bigquery/src/components/shared/read_only_editor.tsx
+++ b/jupyterlab_bigquery/src/components/shared/read_only_editor.tsx
@@ -3,6 +3,7 @@ import { Paper } from '@material-ui/core';
 import Editor from '@monaco-editor/react';
 import { monaco } from '@monaco-editor/react';
 import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
+import { isDarkTheme } from '../../utils/dark_theme';
 
 function handleEditorDidMount(_, editor) {
   const editorElement = editor.getDomNode();
@@ -20,16 +21,14 @@ function handleEditorDidMount(_, editor) {
       const height = lineCount * lineHeight;
       editorElement.style.height = `${height + 0.5 * lineHeight}px`;
       editor.layout();
-      const lightTheme =
-        document.body.getAttribute('data-jp-theme-light') === 'true';
 
       monaco.editor.defineTheme('viewOnlyQueryTheme', {
-        base: lightTheme ? 'vs' : 'vs-dark',
+        base: isDarkTheme() ? 'vs-dark' : 'vs',
         inherit: true,
         rules: [],
         colors: {
-          'editorCursor.foreground': lightTheme ? '#FFFFFF' : '#1E1E1E',
-          'editorGutter.background': lightTheme ? '#f8f9fa' : '#111111',
+          'editorCursor.foreground': isDarkTheme() ? '#1E1E1E' : '#FFFFFF',
+          'editorGutter.background': isDarkTheme() ? '#111111' : '#f8f9fa',
         },
       });
       monaco.editor.setTheme('viewOnlyQueryTheme');

--- a/jupyterlab_bigquery/src/components/shared/schema_table.tsx
+++ b/jupyterlab_bigquery/src/components/shared/schema_table.tsx
@@ -18,14 +18,11 @@ export const localStyles = stylesheet({
   },
 });
 
-// TODO: style for dark mode. Currently defaults to bordercolor3
+// TODO: style for dark mode. Currently does not match striped rows
 export const TableHeadCell: React.ComponentType<any> = withStyles({
   root: {
     color: 'var(--jp-ui-font-color1)',
-    backgroundColor:
-      document.body.getAttribute('data-jp-theme-light') === 'true'
-        ? '#fafafa'
-        : 'var(--jp-border-color3)',
+    backgroundColor: 'var(--jp-rendermime-table-row-background)',
     whiteSpace: 'nowrap',
     fontSize: '13px',
     padding: '4px 16px 4px 16px',

--- a/jupyterlab_bigquery/src/components/shared/schema_table.tsx
+++ b/jupyterlab_bigquery/src/components/shared/schema_table.tsx
@@ -18,13 +18,18 @@ export const localStyles = stylesheet({
   },
 });
 
+// TODO: style for dark mode. Currently defaults to bordercolor3
 export const TableHeadCell: React.ComponentType<any> = withStyles({
   root: {
-    backgroundColor: '#f8f9fa',
+    color: 'var(--jp-ui-font-color1)',
+    backgroundColor:
+      document.body.getAttribute('data-jp-theme-light') === 'true'
+        ? '#fafafa'
+        : 'var(--jp-border-color3)',
     whiteSpace: 'nowrap',
     fontSize: '13px',
     padding: '4px 16px 4px 16px',
-    borderTop: '1px  solid var(--jp-border-color2)',
+    border: 0,
     BASE_FONT,
   },
 })(TableCell);
@@ -46,10 +51,18 @@ const formatFieldName = name => {
 
 const StyledTableCell = withStyles({
   root: {
+    color: 'var(--jp-ui-font-color1)',
     fontSize: '13px',
     BASE_FONT,
+    border: 0,
   },
 })(TableCell);
+
+export const StyledTableRow = withStyles({
+  root: {
+    borderBottom: '1px solid var(--jp-border-color2)',
+  },
+})(TableRow);
 
 export const SchemaTable = (props: { schema: any }) => {
   return (
@@ -62,15 +75,19 @@ export const SchemaTable = (props: { schema: any }) => {
           <TableHeadCell>Description</TableHeadCell>
         </TableRow>
       </TableHead>
-      <TableBody>
+      <TableBody
+        style={{
+          backgroundColor: 'var(--jp-layout-color0)',
+        }}
+      >
         {props.schema.map((field, index) => {
           return (
-            <TableRow key={`schema_row_${index}`}>
+            <StyledTableRow key={`schema_row_${index}`}>
               <StyledTableCell>{formatFieldName(field.name)}</StyledTableCell>
               <StyledTableCell>{field.type}</StyledTableCell>
               <StyledTableCell>{field.mode}</StyledTableCell>
               <StyledTableCell>{field.description ?? ''}</StyledTableCell>
-            </TableRow>
+            </StyledTableRow>
           );
         })}
       </TableBody>
@@ -87,13 +104,18 @@ export const ModelSchemaTable = (props: { schema: any }) => {
           <TableHeadCell>Type</TableHeadCell>
         </TableRow>
       </TableHead>
-      <TableBody>
+      <TableBody
+        style={{
+          color: 'var(--jp-ui-font-color1)',
+          backgroundColor: 'var(--jp-layout-color0)',
+        }}
+      >
         {props.schema.map((field, index) => {
           return (
-            <TableRow key={`schema_row_${index}`}>
+            <StyledTableRow key={`schema_row_${index}`}>
               <StyledTableCell>{formatFieldName(field.name)}</StyledTableCell>
               <StyledTableCell>{field.type}</StyledTableCell>
-            </TableRow>
+            </StyledTableRow>
           );
         })}
       </TableBody>

--- a/jupyterlab_bigquery/src/components/shared/striped_rows.tsx
+++ b/jupyterlab_bigquery/src/components/shared/striped_rows.tsx
@@ -15,7 +15,14 @@ const localStyles = stylesheet({
 });
 
 export const getStripedStyle = index => {
-  return { background: index % 2 ? 'white' : '#fafafa' };
+  return {
+    background:
+      index % 2
+        ? 'var(--jp-layout-color0)'
+        : document.body.getAttribute('data-jp-theme-light') === 'true'
+        ? '#fafafa'
+        : 'var(--jp-border-color3)',
+  };
 };
 
 export const StripedRows = props => {

--- a/jupyterlab_bigquery/src/components/shared/striped_rows.tsx
+++ b/jupyterlab_bigquery/src/components/shared/striped_rows.tsx
@@ -19,9 +19,7 @@ export const getStripedStyle = index => {
     background:
       index % 2
         ? 'var(--jp-layout-color0)'
-        : document.body.getAttribute('data-jp-theme-light') === 'true'
-        ? '#fafafa'
-        : 'var(--jp-border-color3)',
+        : 'var(--jp-rendermime-table-row-background)',
   };
 };
 

--- a/jupyterlab_bigquery/src/components/shared/styles.ts
+++ b/jupyterlab_bigquery/src/components/shared/styles.ts
@@ -1,9 +1,10 @@
+import { isDarkTheme } from '../../utils/dark_theme';
+
 /** Google theme colors. Blue 600, green red yellow 500 for light theme. All 300 vallues for dark theme.*/
 type Color = 'BLUE' | 'RED' | 'GREEN' | 'YELLOW';
 
 export function gColor(color: Color) {
-  const darkTheme =
-    document.body.getAttribute('data-jp-theme-light') === 'false';
+  const darkTheme = isDarkTheme();
   switch (color) {
     case 'BLUE':
       return darkTheme ? '#8AB4F8' : '#1A73E8';

--- a/jupyterlab_bigquery/src/components/shared/styles.ts
+++ b/jupyterlab_bigquery/src/components/shared/styles.ts
@@ -1,0 +1,17 @@
+/** Google theme colors. Blue 600, green red yellow 500 for light theme. All 300 vallues for dark theme.*/
+type Color = 'BLUE' | 'RED' | 'GREEN' | 'YELLOW';
+
+export function gColor(color: Color) {
+  const darkTheme =
+    document.body.getAttribute('data-jp-theme-light') === 'false';
+  switch (color) {
+    case 'BLUE':
+      return darkTheme ? '#8AB4F8' : '#1A73E8';
+    case 'RED':
+      return darkTheme ? '#F28B82' : '#EA4335';
+    case 'GREEN':
+      return darkTheme ? '#81C995' : '#34A853';
+    case 'YELLOW':
+      return darkTheme ? '#FDD663' : '#FBBC04';
+  }
+}

--- a/jupyterlab_bigquery/src/components/shared/tabs.tsx
+++ b/jupyterlab_bigquery/src/components/shared/tabs.tsx
@@ -3,15 +3,21 @@ import { withStyles, Tabs, Tab } from '@material-ui/core';
 
 export const StyledTabs: React.ComponentType<any> = withStyles({
   root: {
-    borderBottom: '1px solid #e8e8e8',
+    borderBottom: '1px solid var(--jp-border-color2)',
     minHeight: 'auto',
     padding: 0,
   },
   indicator: {
-    backgroundColor: '#0d68ff',
     height: '2.5px',
+    backgroundColor: (props: StyledTabsProps) => props.color,
   },
-})(Tabs);
+})((props: StyledTabsProps) => <Tabs {...props} />);
+
+interface StyledTabsProps {
+  value: string | number;
+  onChange: () => void;
+  color: string;
+}
 
 export const StyledTab: React.ComponentType<StyledTabProps> = withStyles({
   root: {
@@ -20,14 +26,16 @@ export const StyledTab: React.ComponentType<StyledTabProps> = withStyles({
     minHeight: 'auto',
     fontSize: '13px',
     '&:hover': {
-      color: '#0d68ff',
+      color: (props: StyledTabProps) => props.color,
       opacity: 1,
     },
-    '&$selected': {
-      color: '#0d68ff',
+    '&selected': {
+      color: (props: StyledTabProps) => props.color,
+      opacity: 1,
     },
     '&:focus': {
-      color: '#0d68ff',
+      color: (props: StyledTabProps) => props.color,
+      opacity: 1,
     },
   },
   selected: {},
@@ -35,6 +43,7 @@ export const StyledTab: React.ComponentType<StyledTabProps> = withStyles({
 
 interface StyledTabProps {
   label: string;
+  color: string;
 }
 
 interface TabPanelProps {

--- a/jupyterlab_bigquery/src/utils/dark_theme.ts
+++ b/jupyterlab_bigquery/src/utils/dark_theme.ts
@@ -1,0 +1,3 @@
+export function isDarkTheme() {
+  return document.body.getAttribute('data-jp-theme-light') === 'false';
+}

--- a/jupyterlab_bigquery/style/index.css
+++ b/jupyterlab_bigquery/style/index.css
@@ -1,31 +1,37 @@
 .jp-BigQueryIcon {
   background-image: url('./images/BigQuery.svg');
-  background-size: contain;
+  filter: initial !important;
 }
 .jp-DatasetIcon {
   background-image: url('./images/dataset_20px.svg');
-  background-size: contain;
 }
 .jp-TableIcon {
   background-image: url('./images/table_20px.svg');
-  background-size: contain;
 }
 .jp-PartitionedTableIcon {
   background-image: url('./images/table_partitioned_18px.svg');
-  background-size: contain;
 }
 .jp-ViewIcon {
   background-image: url('./images/table_view_24px.svg');
-  background-size: contain;
 }
 .jp-ModelIcon {
   background-image: url('./images/model_20px.svg');
-  background-size: contain;
 }
 .jp-OpenEditorIcon {
   background-image: url('./images/open_editor_20px.svg');
-  background-size: contain;
 }
 .jp-OutputArea-child .jp-OutputArea-output {
   overflow: auto;
+}
+
+.jp-Icon {
+  background-size: contain;
+}
+
+[data-jp-theme-light='true'] .jp-Icon {
+  filter: invert(0.4);
+}
+
+[data-jp-theme-light='false'] .jp-Icon {
+  filter: invert(0.6);
 }


### PR DESCRIPTION
![dark](https://user-images.githubusercontent.com/48393093/91992155-cbe8c000-ed01-11ea-8054-9b8c7c18b630.png)

Initial version of dark mode. Most colors are set to jp variables (eg `jp-ui-font-color1`) which change automatically when the theme changes. For colors that don't match jp variables (google blue, red, green, and yellow), there is now a `gColor` function that reads the body attribute `data-jp-theme-light` and returns colors according to the [material style color guides](https://standards.google/guidelines/google-material/styles/color/#palettes).

An issue that still needs to be resolved: because we currently aren't listening to theme change signals, the editor will correctly initialize in a particular theme, but if you change the theme once it's loaded, it will not change accordingly. The user would have to open a new editor or refresh the window.