### PR TITLE
[HardwareConfiguration] Fixing missing framework bug

### DIFF
--- a/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
+++ b/jupyterlab_gcedetails/src/components/hardware_scaling_form.tsx
@@ -95,7 +95,7 @@ export class HardwareScalingForm extends React.Component<Props, State> {
 
     this.state = {
       configuration: this.oldConfiguration,
-      // update the gpu count options based on the selected gpu type
+      // Update the gpu count options based on the selected gpu type
       gpuCountOptions: getGpuCountOptionsList(
         props.details.acceleratorTypes,
         props.details.gpu.name
@@ -118,9 +118,15 @@ export class HardwareScalingForm extends React.Component<Props, State> {
    */
   private canAttachGpu(machineTypeName: string): boolean {
     const { framework } = this.props.details.instance.attributes;
-    const isValidFramework = !GPU_INCOMPATIBLE_FRAMEWORKS.some(
-      incompatibleFramework => framework.startsWith(incompatibleFramework)
-    );
+
+    /** Assume framework is compatible if it can't be fetched as the
+     * reshaping process will catch this error anyways.
+     */
+    const isValidFramework = framework
+      ? !GPU_INCOMPATIBLE_FRAMEWORKS.some(incompatibleFramework =>
+          framework.startsWith(incompatibleFramework)
+        )
+      : true;
     const isValidMachineType = machineTypeName.startsWith(N1_MACHINE_PREFIX);
     return isValidFramework && isValidMachineType;
   }
@@ -197,7 +203,7 @@ export class HardwareScalingForm extends React.Component<Props, State> {
   private submitForm() {
     const configuration = { ...this.state.configuration };
     if (!configuration.attachGpu) {
-      /*
+      /**
        * If configuration originally had a GPU we want to explicity attach an
        * accelerator of type NO_ACCELERATOR_TYPE through the Notebooks API to remove it
        */


### PR DESCRIPTION
Before this PR the extension would crash on the hardware scaling form when doing the framework-GPU compatibility check if a framework wasn't fetched with the GCE metadata. In production this shouldn't be an issue as we assume a framework should always be specified but for the sake of local testing I've added a fix that assumes the framework is compatible with attaching GPUs if a framework isn't specified.