### PR TITLE
[BigQuery] Support legacy sql

### DIFF
--- a/jupyterlab_bigquery/jupyterlab_bigquery/list_items_handler/service.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/list_items_handler/service.py
@@ -71,6 +71,7 @@ class BigQueryService:
           'name': table.table_id,
           'datasetId': dataset_id,
           'type': table.table_type,
+          'legacySql': table.view_use_legacy_sql,
           'partitioned': bool(table.partitioning_type),
       }
       table_ids.append(table_full_id)

--- a/jupyterlab_bigquery/src/components/details_panel/view_details_panel.tsx
+++ b/jupyterlab_bigquery/src/components/details_panel/view_details_panel.tsx
@@ -98,7 +98,15 @@ export default class ViewDetailsPanel extends React.Component<Props, State> {
                   'main',
                   queryId,
                   undefined,
-                  [queryId, getStarterQuery('VIEW', this.props.view_id)]
+                  [
+                    queryId,
+                    getStarterQuery(
+                      'VIEW',
+                      this.props.view_id,
+                      this.state.details.details.legacy_sql
+                    ),
+                    this.state.details.details.legacy_sql,
+                  ]
                 );
               }}
               startIcon={<Code />}

--- a/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab.tsx
@@ -28,6 +28,7 @@ interface QueryEditorTabProps {
   isVisible: boolean;
   queryId?: string;
   iniQuery?: string;
+  useLegacySql?: boolean;
 }
 
 class QueryEditorTab extends React.Component<QueryEditorTabProps, {}> {
@@ -52,6 +53,8 @@ class QueryEditorTab extends React.Component<QueryEditorTabProps, {}> {
         <QueryTextEditor
           queryId={this.queryId}
           iniQuery={this.props.iniQuery}
+          /* eslint-disable-next-line @typescript-eslint/camelcase */
+          queryFlags={{ use_legacy_sql: this.props.useLegacySql }}
         />
         {showResult && <QueryResults queryId={this.queryId} />}
       </div>

--- a/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab_widget.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_editor_tab/query_editor_tab_widget.tsx
@@ -8,7 +8,8 @@ export class QueryEditorTabWidget extends ReduxReactWidget {
   constructor(
     private editorNumber: number,
     private queryId: string,
-    private iniQuery: string
+    private iniQuery: string,
+    private useLegacySql?: boolean
   ) {
     super();
     this.title.label = `Query Editor ${this.editorNumber}`;
@@ -22,6 +23,7 @@ export class QueryEditorTabWidget extends ReduxReactWidget {
         isVisible={this.isVisible}
         queryId={this.queryId}
         iniQuery={this.iniQuery}
+        useLegacySql={this.useLegacySql ?? false}
       />
     );
   }

--- a/jupyterlab_bigquery/src/utils/starter_queries.ts
+++ b/jupyterlab_bigquery/src/utils/starter_queries.ts
@@ -1,9 +1,17 @@
-type QueryType = 'MODEL' | 'TABLE' | 'VIEW';
+export type QueryType = 'MODEL' | 'TABLE' | 'VIEW';
 
-export function getStarterQuery(type: QueryType, resourceId: string) {
+export function getStarterQuery(
+  type: QueryType,
+  resourceId: string,
+  legacySql?: boolean
+) {
   if (type === 'MODEL') {
     return `SELECT * FROM ML.PREDICT(MODEL \`${resourceId}\`, )`;
   } else {
-    return `SELECT * FROM \`${resourceId}\` LIMIT 1000`;
+    if (legacySql) {
+      return `SELECT * FROM [${resourceId}] LIMIT 1000`;
+    } else {
+      return `SELECT * FROM \`${resourceId}\` LIMIT 1000`;
+    }
   }
 }


### PR DESCRIPTION
When a view is in legacy sql, opening an editor from the details panel or context menu will ensure the editor is set to legacy sql as well.