### PR TITLE
[BigQuery] Snackbar with autohide when copying

### DIFF
--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
@@ -86,6 +86,7 @@ interface ResourceProps {
   context: Context;
   updateProject?: any;
   updateDataset?: any;
+  openSnackbar?: any;
 }
 
 export interface ModelProps extends ResourceProps {
@@ -105,7 +106,6 @@ export interface ProjectProps extends ResourceProps {
   project: Project;
   updateProject: any;
   updateDataset: any;
-  openSnackbar: any;
   removeProject: any;
   collapseAll?: boolean;
   updateCollapseAll?: any;
@@ -133,10 +133,18 @@ export class Resource<T extends ResourceProps> extends React.Component<
   }
 
   copyID = dataTreeItem => {
+    this.props.openSnackbar({
+      message: 'ID copied',
+      autoHideDuration: 2000,
+    });
     Clipboard.copyToSystem(dataTreeItem.id);
   };
 
   copyBoilerplateQuery = dataTreeItem => {
+    this.props.openSnackbar({
+      message: 'Query copied',
+      autoHideDuration: 2000,
+    });
     Clipboard.copyToSystem(getStarterQuery(dataTreeItem.type, dataTreeItem.id));
   };
 
@@ -473,6 +481,7 @@ export class DatasetResource extends Resource<DatasetProps> {
                   <TableResource
                     context={this.props.context}
                     table={dataset.tables[tableId]}
+                    openSnackbar={this.props.openSnackbar}
                   />
                 </div>
               ))}
@@ -481,6 +490,7 @@ export class DatasetResource extends Resource<DatasetProps> {
                   <ModelResource
                     context={this.props.context}
                     model={dataset.models[modelId]}
+                    openSnackbar={this.props.openSnackbar}
                   />
                 </div>
               ))}
@@ -510,7 +520,7 @@ export class ProjectResource extends Resource<ProjectProps> {
   listDatasetsService = new ListDatasetsService();
 
   handleOpenSnackbar = error => {
-    this.props.openSnackbar(error);
+    this.props.openSnackbar({ message: error });
   };
 
   expandProject = project => {
@@ -627,6 +637,7 @@ export class ProjectResource extends Resource<ProjectProps> {
                   context={this.props.context}
                   dataset={project.datasets[datasetId]}
                   updateDataset={this.props.updateDataset}
+                  openSnackbar={this.props.openSnackbar}
                 />
               </div>
             ))

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
@@ -32,6 +32,7 @@ import { ModelDetailsWidget } from '../details_panel/model_details_widget';
 import { ModelDetailsService } from '../details_panel/service/list_model_details';
 import { getStarterQuery, QueryType } from '../../utils/starter_queries';
 import { gColor } from '../shared/styles';
+import { COPIED_AUTOHIDE_DURATION } from '../shared/snackbar';
 
 import { ContextMenu } from 'gcp_jupyterlab_shared';
 
@@ -135,7 +136,7 @@ export class Resource<T extends ResourceProps> extends React.Component<
   copyID = dataTreeItem => {
     this.props.openSnackbar({
       message: 'ID copied',
-      autoHideDuration: 2000,
+      autoHideDuration: COPIED_AUTOHIDE_DURATION,
     });
     Clipboard.copyToSystem(dataTreeItem.id);
   };
@@ -143,7 +144,7 @@ export class Resource<T extends ResourceProps> extends React.Component<
   copyBoilerplateQuery = dataTreeItem => {
     this.props.openSnackbar({
       message: 'Query copied',
-      autoHideDuration: 2000,
+      autoHideDuration: COPIED_AUTOHIDE_DURATION,
     });
     Clipboard.copyToSystem(getStarterQuery(dataTreeItem.type, dataTreeItem.id));
   };

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
@@ -41,7 +41,7 @@ import {
 import { SearchBar } from './search_bar';
 import { gColor } from '../shared/styles';
 import { DialogComponent, BASE_FONT } from 'gcp_jupyterlab_shared';
-import CustomSnackbar from './snackbar';
+import CustomSnackbar from '../shared/snackbar';
 
 interface Props {
   listProjectsService: ListProjectsService;

--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_panel.tsx
@@ -251,10 +251,10 @@ class ListItemsPanel extends React.Component<Props, State> {
     } catch (err) {
       console.warn('Error searching', err.message);
       this.handleOpenSearchDialog();
-      this.props.openSnackbar(
-        `Error: Searching not allowed in project ${project}. 
-        Enable the Data Catalog API in this project to continue.`
-      );
+      this.props.openSnackbar({
+        message: `Error: Searching not allowed in project ${project}. 
+        Enable the Data Catalog API in this project to continue.`,
+      });
     }
   }
 
@@ -294,7 +294,9 @@ class ListItemsPanel extends React.Component<Props, State> {
           this.props.addProject(project);
         } else {
           console.log('This project does not exist');
-          this.props.openSnackbar(`Project ${newProjectId} does not exist.`);
+          this.props.openSnackbar({
+            message: `Project ${newProjectId} does not exist.`,
+          });
         }
       });
     } catch (err) {
@@ -373,7 +375,11 @@ class ListItemsPanel extends React.Component<Props, State> {
     return (
       <div className={localStyles.panel}>
         <Portal>
-          <CustomSnackbar open={snackbar.open} message={snackbar.message} />
+          <CustomSnackbar
+            open={snackbar.open}
+            message={snackbar.message}
+            autoHideDuration={snackbar.autoHideDuration}
+          />
         </Portal>
         <header className={localStyles.header}>
           <div className={localStyles.headerTitle}>BigQuery extension</div>

--- a/jupyterlab_bigquery/src/components/list_items_panel/snackbar.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/snackbar.tsx
@@ -9,6 +9,7 @@ interface Props {
   open: boolean;
   message: string;
   closeSnackbar: any;
+  autoHideDuration: number;
 }
 
 function CustomSnackbar(props: React.PropsWithChildren<Props>) {
@@ -21,12 +22,14 @@ function CustomSnackbar(props: React.PropsWithChildren<Props>) {
     }
     props.closeSnackbar();
   };
+
   return (
     <Snackbar
       anchorOrigin={{
         vertical: 'bottom',
         horizontal: 'right',
       }}
+      autoHideDuration={props.autoHideDuration}
       open={props.open}
       onClose={handleClose}
       message={props.message}

--- a/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_text_editor.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_text_editor.tsx
@@ -37,6 +37,7 @@ import { formatBytes } from '../../../utils/formatters';
 import QueryResultsManager from '../../../utils/QueryResultsManager';
 import { isDarkTheme } from '../../../utils/dark_theme';
 import { SnackbarState, openSnackbar } from '../../../reducers/snackbarSlice';
+import { COPIED_AUTOHIDE_DURATION } from '../../shared/snackbar';
 
 interface QueryTextEditorState {
   queryState: QueryStates;
@@ -633,7 +634,7 @@ class QueryTextEditor extends React.Component<
           copy(query.trim());
           this.props.openSnackbar({
             message: 'Query copied',
-            autoHideDuration: 2000,
+            autoHideDuration: COPIED_AUTOHIDE_DURATION,
           });
         }}
       >

--- a/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_text_editor.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_text_editor.tsx
@@ -36,6 +36,7 @@ import { QueryEditorTabWidget } from '../query_editor_tab/query_editor_tab_widge
 import { formatBytes } from '../../../utils/formatters';
 import QueryResultsManager from '../../../utils/QueryResultsManager';
 import { isDarkTheme } from '../../../utils/dark_theme';
+import { SnackbarState, openSnackbar } from '../../../reducers/snackbarSlice';
 
 interface QueryTextEditorState {
   queryState: QueryStates;
@@ -57,6 +58,8 @@ interface QueryTextEditorProps {
   onQueryChange?: (string) => void;
   onQueryFInish?: (Array) => void;
   showResult?: boolean;
+  snackbar: SnackbarState;
+  openSnackbar: any;
 }
 
 interface QueryResponseType {
@@ -628,6 +631,10 @@ class QueryTextEditor extends React.Component<
         onClick={_ => {
           const query = this.editor.getValue();
           copy(query.trim());
+          this.props.openSnackbar({
+            message: 'Query copied',
+            autoHideDuration: 2000,
+          });
         }}
       >
         <FileCopyOutlined fontSize="small" className={styleSheet.icon} />
@@ -727,14 +734,16 @@ class QueryTextEditor extends React.Component<
   }
 }
 
-const mapStateToProps = _ => {
-  return {};
+const mapStateToProps = state => {
+  const snackbar = state.snackbar;
+  return { snackbar };
 };
 
 const mapDispatchToProps = {
   updateQueryResult,
   resetQueryResult,
   deleteQueryEntry,
+  openSnackbar,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(QueryTextEditor);

--- a/jupyterlab_bigquery/src/components/shared/snackbar.tsx
+++ b/jupyterlab_bigquery/src/components/shared/snackbar.tsx
@@ -5,6 +5,8 @@ import { Snackbar, IconButton } from '@material-ui/core';
 import { connect } from 'react-redux';
 import { closeSnackbar } from '../../reducers/snackbarSlice';
 
+export const COPIED_AUTOHIDE_DURATION = 2000;
+
 interface Props {
   open: boolean;
   message: string;

--- a/jupyterlab_bigquery/src/reducers/snackbarSlice.ts
+++ b/jupyterlab_bigquery/src/reducers/snackbarSlice.ts
@@ -3,25 +3,30 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 export interface SnackbarState {
   open: boolean;
   message: string;
+  autoHideDuration: number;
 }
 
 const initialState: SnackbarState = {
   open: false,
-  message: 'Error',
+  message: '',
+  autoHideDuration: null,
 };
 
 const snackbarSlice = createSlice({
   name: 'snackbar',
   initialState,
   reducers: {
-    openSnackbar(state, action: PayloadAction<string>) {
-      const snackbarMessage = action.payload;
+    openSnackbar(
+      state,
+      action: PayloadAction<{ message: string; autoHideDuration: number }>
+    ) {
+      const { message, autoHideDuration } = action.payload;
       state.open = true;
-      state.message = snackbarMessage;
+      state.message = message;
+      state.autoHideDuration = autoHideDuration ?? null;
     },
     closeSnackbar(state) {
       state.open = false;
-      state.message = initialState.message;
     },
   },
 });


### PR DESCRIPTION
Adds a snackbar popup when a user copies from the context menu or from the query editor top bar. 

Alters the snackbar component - now you can pass in a duration in ms before the snackbar automatically disappears. The one that pops up after you copy something lasts for 2 seconds.