### PR TITLE
[BigQuery] Editor tweaks

### DIFF
--- a/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_text_editor.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_text_editor.tsx
@@ -92,6 +92,7 @@ const SQL_EDITOR_OPTIONS: editor.IEditorConstructionOptions = {
   wrappingStrategy: 'advanced',
   minimap: { enabled: false },
   cursorStyle: 'line-thin',
+  scrollBeyondLastLine: false,
 };
 
 const styleSheet = stylesheet({

--- a/jupyterlab_bigquery/src/components/shared/bq_table.tsx
+++ b/jupyterlab_bigquery/src/components/shared/bq_table.tsx
@@ -227,17 +227,18 @@ export class BQTable extends React.Component<Props, State> {
             </TableBody>
           </Table>
         </div>
-        {/* TODO(cxjia): hide table pagination when result rows <= 10 */}
-        <StyledPagination
-          rowsPerPageOptions={[10, 30, 50, 100, 200]}
-          count={rows.length}
-          rowsPerPage={rowsPerPage}
-          page={page}
-          onChangePage={this.handleChangePage.bind(this)}
-          onChangeRowsPerPage={this.handleChangeRowsPerPage.bind(this)}
-          ActionsComponent={TablePaginationActions}
-          component="div"
-        />
+        {rows.length > 10 && (
+          <StyledPagination
+            rowsPerPageOptions={[10, 30, 50, 100, 200]}
+            count={rows.length}
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onChangePage={this.handleChangePage.bind(this)}
+            onChangeRowsPerPage={this.handleChangeRowsPerPage.bind(this)}
+            ActionsComponent={TablePaginationActions}
+            component="div"
+          />
+        )}
       </>
     );
   }


### PR DESCRIPTION
- Removes `scrollBeyondLastLine` which adds several lines at the end of the editor - this previously made scrolling difficult when trying to scroll past an in-cell editor within a notebook.
- Only shows pagination options if there are 10 rows in a query result or more.