### PR TITLE
[BigQuery] Stop propagation on open query button in Query History

### DIFF
--- a/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
+++ b/jupyterlab_bigquery/src/components/query_history/query_history_panel.tsx
@@ -249,7 +249,8 @@ const QueryBar = (props: { jobs: JobsObject; jobId: string }) => {
       <div className={localStyles.query}>{jobs[jobId].query}</div>
       <button
         className={localStyles.openQueryButtonSmall}
-        onClick={() => {
+        onClick={event => {
+          event.stopPropagation();
           const queryId = generateQueryId();
           WidgetManager.getInstance().launchWidget(
             QueryEditorTabWidget,


### PR DESCRIPTION
Now when pressing the open query button on a past query, it prevents the `collapse` panel from also opening unnecessarily. 