### PR TITLE
[BigQuery] Fix infinite loading when datasets are expanded, and project is collapsed and re-opened

### DIFF
--- a/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
+++ b/jupyterlab_bigquery/src/components/list_items_panel/list_tree_item.tsx
@@ -379,7 +379,7 @@ export class DatasetResource extends Resource<DatasetProps> {
     super(props);
     this.state = {
       expanded: [],
-      loading: true,
+      loading: false,
     };
   }
 


### PR DESCRIPTION
Previously if a user expanded a dataset, then collapsed the parent project and then re-opened that parent project, the previously open dataset would be stuck loading forever.

This fixes the issue by changing the initial loading state for dataset resources to `false` so that they will only be set to a loading status if they are actually fetching tables.