### PR TITLE
Fix handling of base64 files in GCSContentsManager

### DIFF
--- a/jupyter-gcs-contents-manager/gcs_contents_manager.py
+++ b/jupyter-gcs-contents-manager/gcs_contents_manager.py
@@ -404,6 +404,9 @@ class GCSContentsManager(ContentsManager):
       contents = model['content']
       if model['type'] == 'notebook':
         contents = nbformat.writes(nbformat.from_dict(contents))
+      elif model['type'] == 'file' and model['format'] == 'base64':
+        b64_bytes = contents.encode('ascii')
+        contents = base64.decodebytes(b64_bytes)
 
       # GCS doesn't allow specifying the key version, so drop it if present
       if blob.kms_key_name:


### PR DESCRIPTION
The default FileContentsManager decodes base64 files at save time (https://github.com/jupyter/notebook/blob/94af525a2c0aaa99311647c6cccf9add07a63033/notebook/services/contents/fileio.py#L334). This is important as files uploaded through the UI will be base64-encoded: the fact that we currently don't decode files before saving them to GCS means that Jupyter cannot later open these files.

For consistency with the Jupyter default contents manager, only decodes if the file is of type 'file'. This still works for uploading notebooks as the file type at first upload is always 'file'.