### PR TITLE
[Git Sync] File Conflicts Handling

### DIFF
--- a/jupyterlab_gitsync/package-lock.json
+++ b/jupyterlab_gitsync/package-lock.json
@@ -1207,12 +1207,11 @@
       }
     },
     "@material-ui/icons": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-3.0.2.tgz",
-      "integrity": "sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.9.1.tgz",
+      "integrity": "sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "recompose": "0.28.0 - 0.30.0"
+        "@babel/runtime": "^7.4.4"
       }
     },
     "@material-ui/styles": {
@@ -1345,11 +1344,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -1411,11 +1405,6 @@
         "supports-color": "^5.3.0"
       }
     },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
-    },
     "clsx": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
@@ -1455,11 +1444,6 @@
           "dev": true
         }
       }
-    },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -1564,14 +1548,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-    },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      }
     },
     "enquirer": {
       "version": "2.3.6",
@@ -1787,20 +1763,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      }
-    },
     "file-entry-cache": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
@@ -1907,14 +1869,6 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
-    "iconv-lite": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      }
-    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1980,24 +1934,10 @@
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
       "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2196,15 +2136,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
-    },
     "node-releases": {
       "version": "1.1.60",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
@@ -2294,14 +2225,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -2322,11 +2245,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-scroll": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.8.1.tgz",
@@ -2345,26 +2263,6 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
-      }
-    },
-    "recompose": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "react-lifecycles-compat": "^3.0.2",
-        "symbol-observable": "^1.0.4"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        }
       }
     },
     "regenerate": {
@@ -2461,21 +2359,11 @@
         "glob": "^7.1.3"
       }
     },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -2551,11 +2439,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -2595,11 +2478,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
-    },
-    "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -2641,11 +2519,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
       "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
-    },
-    "whatwg-fetch": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
-      "integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
     },
     "which": {
       "version": "2.0.2",

--- a/jupyterlab_gitsync/package.json
+++ b/jupyterlab_gitsync/package.json
@@ -49,7 +49,7 @@
     "@jupyterlab/ui-components": "^1.2.1",
     "@lumino/signaling": "^1.4.3",
     "@material-ui/core": "^4.10.1",
-    "@material-ui/icons": "^3.0.2",
+    "@material-ui/icons": "^4.9.1",
     "@phosphor/algorithm": "^1.2.0",
     "@phosphor/commands": "^1.7.0",
     "@phosphor/coreutils": "^1.3.1",

--- a/jupyterlab_gitsync/src/components/git_setup/branch_setup.tsx
+++ b/jupyterlab_gitsync/src/components/git_setup/branch_setup.tsx
@@ -9,10 +9,12 @@ import {
   setupItemInnerClass,
 } from '../../style/setup';
 
-import FormControl from '@material-ui/core/FormControl';
-import FormHelperText from '@material-ui/core/FormHelperText';
-import Select from '@material-ui/core/Select';
-import MenuItem from '@material-ui/core/MenuItem';
+import {
+  FormControl,
+  FormHelperText,
+  MenuItem,
+  Select,
+} from '@material-ui/core';
 
 interface GitBranchState {
   disabled: boolean;

--- a/jupyterlab_gitsync/src/components/git_setup/path_setup.tsx
+++ b/jupyterlab_gitsync/src/components/git_setup/path_setup.tsx
@@ -9,9 +9,7 @@ import {
   setupItemInnerClass,
 } from '../../style/setup';
 
-import FormControl from '@material-ui/core/FormControl';
-import FormHelperText from '@material-ui/core/FormHelperText';
-import OutlinedInput from '@material-ui/core/OutlinedInput';
+import { FormControl, FormHelperText, OutlinedInput } from '@material-ui/core';
 
 interface GitPathState {
   path: string;

--- a/jupyterlab_gitsync/src/components/log_panel/sync_log.tsx
+++ b/jupyterlab_gitsync/src/components/log_panel/sync_log.tsx
@@ -16,6 +16,10 @@ import ListItem from '@material-ui/core/ListItem';
 import Divider from '@material-ui/core/Divider';
 import Typography from '@material-ui/core/Typography';
 
+const hiddenClass = style({
+  display: 'none',
+});
+
 interface SyncLogState {
   hidden: boolean;
   entries: {
@@ -24,10 +28,6 @@ interface SyncLogState {
     error?: boolean;
   }[];
 }
-
-const hiddenClass = style({
-  display: 'none',
-});
 
 export class SyncLog extends React.Component<Props, SyncLogState> {
   scroll = false;
@@ -144,7 +144,7 @@ export class SyncLog extends React.Component<Props, SyncLogState> {
       this.setState({ entries: entries });
     });
 
-    this.props.service.stateChange.connect((_, running) => {
+    this.props.service.runningChange.connect((_, running) => {
       const entries = this.state.entries;
       if (running) {
         entries.push({

--- a/jupyterlab_gitsync/src/components/toolbar_buttons/control_button.tsx
+++ b/jupyterlab_gitsync/src/components/toolbar_buttons/control_button.tsx
@@ -10,6 +10,7 @@ interface ControlButtonState {
   title: string;
   icon: any;
   isRunning: boolean;
+  disabled: boolean;
 }
 
 export class ControlButton extends React.Component<Props, ControlButtonState> {
@@ -19,6 +20,7 @@ export class ControlButton extends React.Component<Props, ControlButtonState> {
       title: 'Start Auto Sync',
       icon: <PlayArrowIcon fontSize="small" />,
       isRunning: false,
+      disabled: false,
     };
   }
 
@@ -32,6 +34,7 @@ export class ControlButton extends React.Component<Props, ControlButtonState> {
         title={this.state.title}
         color="inherit"
         onClick={() => this._onClick()}
+        disabled={this.state.disabled}
       >
         {this.state.icon}
       </IconButton>
@@ -63,9 +66,13 @@ export class ControlButton extends React.Component<Props, ControlButtonState> {
   }
 
   private _addListeners() {
-    this.props.service.stateChange.connect((_, running) => {
+    this.props.service.runningChange.connect((_, running) => {
       if (running && !this.state.isRunning) this._setRunState();
       else if (!running && this.state.isRunning) this._setStopState();
+    });
+
+    this.props.service.blockedChange.connect((_, blocked) => {
+      this.setState({ disabled: blocked });
     });
   }
 }

--- a/jupyterlab_gitsync/src/components/toolbar_buttons/settings_button.tsx
+++ b/jupyterlab_gitsync/src/components/toolbar_buttons/settings_button.tsx
@@ -17,9 +17,9 @@ import {
   Typography,
 } from '@material-ui/core';
 
+import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import SettingsIcon from '@material-ui/icons/Settings';
 import TimerIcon from '@material-ui/icons/Timer';
-import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 
 interface SettingsButtonState {
   open: boolean;
@@ -107,7 +107,11 @@ export class SettingsButton extends React.Component<
             <Button onClick={() => this._onClose()} color="primary">
               Cancel
             </Button>
-            <Button onClick={() => this._onSave()} color="primary">
+            <Button
+              onClick={() => this._onSave()}
+              color="primary"
+              variant="contained"
+            >
               Save
             </Button>
           </DialogActions>

--- a/jupyterlab_gitsync/src/components/toolbar_buttons/status_button.tsx
+++ b/jupyterlab_gitsync/src/components/toolbar_buttons/status_button.tsx
@@ -3,11 +3,10 @@ import { classes, style } from 'typestyle';
 
 import { Props } from '../panel';
 
-import { IconButton } from '@material-ui/core';
-import CircularProgress from '@material-ui/core/CircularProgress';
-import SyncProblemIcon from '@material-ui/icons/SyncProblem';
-import DoneAllIcon from '@material-ui/icons/DoneAll';
+import { CircularProgress, IconButton } from '@material-ui/core';
 import DoneIcon from '@material-ui/icons/Done';
+import DoneAllIcon from '@material-ui/icons/DoneAll';
+import SyncProblemIcon from '@material-ui/icons/SyncProblem';
 
 interface StatusButtonState {
   title: string;

--- a/jupyterlab_gitsync/src/components/toolbar_buttons/sync_button.tsx
+++ b/jupyterlab_gitsync/src/components/toolbar_buttons/sync_button.tsx
@@ -5,9 +5,20 @@ import { Props } from '../panel';
 import { IconButton } from '@material-ui/core';
 import SyncIcon from '@material-ui/icons/Sync';
 
-export class SyncButton extends React.Component<Props, {}> {
+interface SyncButtonState {
+  disabled: boolean;
+}
+
+export class SyncButton extends React.Component<Props, SyncButtonState> {
   constructor(props) {
     super(props);
+    this.state = {
+      disabled: false,
+    };
+  }
+
+  componentDidMount() {
+    this._addListeners();
   }
 
   render() {
@@ -16,6 +27,7 @@ export class SyncButton extends React.Component<Props, {}> {
         title="Sync Repository Once"
         color="inherit"
         onClick={() => this._onClick()}
+        disabled={this.state.disabled}
       >
         <SyncIcon fontSize="small" />
       </IconButton>
@@ -24,5 +36,11 @@ export class SyncButton extends React.Component<Props, {}> {
 
   private _onClick(): void {
     this.props.service.sync();
+  }
+
+  private _addListeners() {
+    this.props.service.blockedChange.connect((_, blocked) => {
+      this.setState({ disabled: blocked });
+    });
   }
 }

--- a/jupyterlab_gitsync/src/index.ts
+++ b/jupyterlab_gitsync/src/index.ts
@@ -5,12 +5,17 @@ import {
   JupyterFrontEndPlugin,
   ILabShell,
 } from '@jupyterlab/application';
+import { IDocumentManager } from '@jupyterlab/docmanager';
 
 import { GitSyncService } from './service/service';
 import { GitSyncWidget } from './components/panel';
 
-async function activate(app: JupyterFrontEnd, shell: ILabShell) {
-  const service = new GitSyncService(shell);
+async function activate(
+  app: JupyterFrontEnd,
+  shell: ILabShell,
+  manager: IDocumentManager
+) {
+  const service = new GitSyncService(shell, manager);
   const widget = new GitSyncWidget(service);
   app.shell.add(widget, 'left', { rank: 100 });
   console.log('git widget activated');
@@ -20,7 +25,7 @@ async function activate(app: JupyterFrontEnd, shell: ILabShell) {
  */
 const GitSyncPlugin: JupyterFrontEndPlugin<void> = {
   id: 'gitsync:gitsync',
-  requires: [ILabShell],
+  requires: [ILabShell, IDocumentManager],
   activate: activate,
   autoStart: true,
 };

--- a/jupyterlab_gitsync/src/service/git.ts
+++ b/jupyterlab_gitsync/src/service/git.ts
@@ -12,7 +12,7 @@ export class GitManager {
   // Member Fields
   private _path: string = undefined;
   private _branch: string = undefined;
-  private _collab: boolean = true;
+  private _collab = true;
   private _branches: string[] = [];
 
   private _setupChange: Signal<this, string> = new Signal<this, string>(this);

--- a/jupyterlab_gitsync/src/service/nbmerge_api.ts
+++ b/jupyterlab_gitsync/src/service/nbmerge_api.ts
@@ -323,3 +323,9 @@ export function mergeNotebooks(base, local, remote) {
   merged.cells = result.value;
   return { content: merged, conflict: result.conflict, source: result.source };
 }
+
+export function notebooksAreEqual(local, remote) {
+  const local_str = getContents(local.cells, CELL_DIVIDER);
+  const remote_str = getContents(remote.cells, CELL_DIVIDER);
+  return local_str === remote_str;
+}

--- a/jupyterlab_gitsync/src/service/text_resolver.ts
+++ b/jupyterlab_gitsync/src/service/text_resolver.ts
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { CodeMirror } from 'codemirror';
-import { Dialog, showDialog } from '@jupyterlab/apputils';
-import { ISignal, Signal } from '@lumino/signaling';
 import * as diff3 from 'node-diff3';
 
 import { IResolver } from './tracker';
@@ -38,9 +36,6 @@ export class TextResolver implements IResolver {
   };
 
   private _conflict: boolean;
-  private _conflictState: Signal<this, boolean> = new Signal<this, boolean>(
-    this
-  );
 
   constructor(file: TextFile) {
     this._file = file;
@@ -60,10 +55,6 @@ export class TextResolver implements IResolver {
 
   get versions(): Versions {
     return this._versions;
-  }
-
-  get conflictState(): ISignal<this, boolean> {
-    return this._conflictState;
   }
 
   setCursorToken(pos: CodeMirror.Pos): void {
@@ -96,11 +87,12 @@ export class TextResolver implements IResolver {
     this._versions[origin] = content;
   }
 
-  async mergeVersions(): Promise<string> {
+  mergeVersions(): string {
     if (this.versions.local === this.versions.remote) {
       this.addVersion(this.versions.local, 'base');
       return undefined;
     }
+
     const result = diff3.merge(
       this.versions.local_tok,
       this.versions.base,
@@ -123,55 +115,13 @@ export class TextResolver implements IResolver {
     const text = result.result.join('\n');
     this._versions.merged_tok = text;
     this._versions.merged = text.replace(this._token, '');
+
     if (result.conflict) {
-      await this._resolveDialog();
+      this._conflict = true;
+      return undefined;
+    } else {
+      this._conflict = false;
+      return this.versions.merged;
     }
-
-    this._updateState(false);
-    return this.versions.merged;
-  }
-
-  private _updateState(state: boolean): void {
-    if (state !== this.conflict) {
-      this._conflict = state;
-      this._conflictState.emit(state);
-    }
-  }
-
-  private async _resolveDialog(): Promise<void> {
-    const body = `"${this.path}" has a conflict. Would you like to revert to a previous version\
-      \nor view the diff? (Note that ignoring conflicts will stop git sync.)`;
-    // const resolveBtn = Dialog.okButton({ label: 'Resolve Conflicts' });
-    const localBtn = Dialog.okButton({ label: 'Revert to Local' });
-    const remoteBtn = Dialog.okButton({ label: 'Revert to Remote' });
-    const diffBtn = Dialog.okButton({ label: 'View Diff' });
-    const ignoreBtn = Dialog.warnButton({ label: 'Ignore Conflict' });
-    return showDialog({
-      title: 'Merge Conflicts',
-      body,
-      buttons: [ignoreBtn, remoteBtn, localBtn, diffBtn],
-    }).then(result => {
-      if (result.button.label === 'Revert to Local') {
-        this._versions.merged = this.versions.local;
-        this._versions.merged_tok = this.versions.local_tok;
-      }
-      if (result.button.label === 'Revert to Remote') {
-        this._versions.merged = this.versions.remote;
-        this._versions.merged_tok = undefined;
-      }
-      if (result.button.label === 'View Diff') {
-        this._versions.merged_tok = undefined;
-      }
-      if (result.button.label === 'Resolve Conflicts') {
-        console.log('do something');
-        // TO DO (ashleyswang) : open an editor for 3 way merging
-      }
-      if (result.button.label === 'Ignore') {
-        this._updateState(true);
-        throw new Error(
-          'ConflictError: Unresolved conflicts in repository. Stopping sync procedure.'
-        );
-      }
-    });
   }
 }

--- a/jupyterlab_gitsync/src/service/tracker.ts
+++ b/jupyterlab_gitsync/src/service/tracker.ts
@@ -16,10 +16,9 @@ export interface IResolver {
   file: IFile;
   path: string;
   conflict: boolean;
-  conflictState: ISignal<this, boolean>;
 
   addVersion(content: any, origin: string): void;
-  mergeVersions(): Promise<any>;
+  mergeVersions(): any;
 }
 
 // eslint-disable-next-line @typescript-eslint/interface-name-prefix
@@ -27,13 +26,16 @@ export interface IFile {
   widget: IDocumentWidget;
   context: DocumentRegistry.Context;
   path: string;
-  conflictState: ISignal<this, boolean>;
+  mergeState: ISignal<this, string>;
   dirtyState: ISignal<this, boolean>;
   resolver: IResolver;
   repoPath: string;
 
   save(): Promise<void>;
-  reload(): Promise<void>;
+  viewDiff(): Promise<void>;
+  reveal(): Promise<void>;
+  markResolved(): Promise<void>;
+  reload(): Promise<IFile>;
 }
 
 export class FileTracker {
@@ -43,10 +45,10 @@ export class FileTracker {
   current: IFile;
   opened: IFile[] = [];
   conflicts: IFile[] = [];
-  changed: IFile[] = [];
+  dirty: IFile[] = [];
 
   conflict: boolean;
-  dirty: boolean;
+  isDirty: boolean;
 
   private _conflictState: Signal<this, boolean> = new Signal<this, boolean>(
     this
@@ -68,17 +70,24 @@ export class FileTracker {
   }
 
   async saveAll() {
-    const promises = this.opened.map(async file => {
-      return await file.save();
+    const promises = this.opened.map(file => {
+      return file.save();
     });
     await Promise.all(promises);
   }
 
   async reloadAll() {
-    const promises = this.opened.map(async file => {
-      return await file.reload();
+    const promises = this.opened.map(file => {
+      return file.reload();
     });
-    await Promise.all(promises);
+
+    const fulfilled = (await Promise.all(promises)).filter(
+      x => x !== undefined
+    );
+    if (fulfilled.length) {
+      this.conflicts = fulfilled;
+      this._updateState('conflict', true);
+    }
   }
 
   private _addListener(signal: ISignal<any, any>, callback: any) {
@@ -90,7 +99,7 @@ export class FileTracker {
   }
 
   private _updateState(type: 'conflict' | 'dirty', state: boolean) {
-    const curr = type === 'conflict' ? this.conflict : this.dirty;
+    const curr = type === 'conflict' ? this.conflict : this.isDirty;
     const signal = type === 'conflict' ? this._conflictState : this._dirtyState;
 
     if (state !== curr) {
@@ -98,7 +107,7 @@ export class FileTracker {
         this.conflict = state;
       }
       if (type === 'dirty') {
-        this.dirty = state;
+        this.isDirty = state;
       }
       signal.emit(state);
     }
@@ -118,13 +127,13 @@ export class FileTracker {
     else {
       file =
         widget instanceof NotebookPanel
-          ? new NotebookFile(widget)
-          : new TextFile(widget);
+          ? new NotebookFile(widget, this.service.manager)
+          : new TextFile(widget, this.service.manager);
       this.current = file;
       this.opened.push(file);
 
       this._addListener(file.widget.disposed, this._disposedListener);
-      this._addListener(file.conflictState, this._conflictListener);
+      this._addListener(file.mergeState, this._conflictListener);
       this._addListener(file.dirtyState, this._dirtyStateListener);
     }
   }
@@ -134,32 +143,29 @@ export class FileTracker {
     const i = this.opened.indexOf(file);
     this.opened.splice(i, 1);
 
-    this._removeListener(file.conflictState, this._conflictListener);
+    this._removeListener(file.mergeState, this._conflictListener);
     this._removeListener(file.dirtyState, this._dirtyStateListener);
   }
 
-  private _conflictListener(sender: IFile, conflict: boolean) {
-    if (!conflict) {
+  private _conflictListener(sender: IFile, state: string) {
+    if (state === 'resolved') {
       const i = this.conflicts.indexOf(sender);
       this.conflicts.splice(i, 1);
       if (this.conflicts.length === 0) {
         this._updateState('conflict', false);
       }
-    } else {
-      this.conflicts.push(sender);
-      this._updateState('conflict', true);
     }
   }
 
   private _dirtyStateListener(sender: IFile, dirty: boolean) {
     if (!dirty) {
-      const i = this.changed.indexOf(sender);
-      this.changed.splice(i, 1);
-      if (this.changed.length === 0) {
+      const i = this.dirty.indexOf(sender);
+      this.dirty.splice(i, 1);
+      if (this.dirty.length === 0) {
         this._updateState('dirty', false);
       }
     } else {
-      this.changed.push(sender);
+      this.dirty.push(sender);
       this._updateState('dirty', true);
     }
   }


### PR DESCRIPTION
**File Conflict Handling**
Change conflict handling implementation in preparation for file conflict ui component. The primary goal is to have a single event listener when the service has all file conflicts to avoid having to unnecessarily re-render components.
* `GitSyncService`:
    * only emit `setupChange` if repo path changes (change how values are sent to listeners)
    * add `blockedChange` signal to disable sync controls when conflicts occur
    * automatic start of sync if sync was running before blocked state
* `FileTracker`: 
    * checks for conflicts after reloading all files (instead of using listeners for individual files)
    * emits conflict signal after checking all files (instead of emitting at the first file conflict)
* `TextFile & NotebookFile`: 
    * add functions to open editor, view diff, and mark as resolved
    * implement `context, content, editor` as getters to avoid getting old widget data
    * `nbmerge_api.ts`: add comparison function to avoid reloading if possible
* `TextResolver & NotebookResolver`: 
    * remove dialog to be displayed by UI component
    * no longer emitting conflict state directly to avoid unnecessary UI state updates when displaying conflicting files

**UI Changes**
*  `ControlButton & SyncButton`: disable syncing when there are unresolved conflicts
* `SettingsButton`: make confirmation button more prominent 