### PR TITLE
Fix issue where service worker result concats undefined.

### DIFF
--- a/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_text_editor.tsx
+++ b/jupyterlab_bigquery/src/components/query_editor/query_text_editor/query_text_editor.tsx
@@ -200,7 +200,7 @@ function workerFunc(e, batchSize) {
 
     this.postMessage({ batch, finish: false });
   }
-  this.postMessage({ batch: undefined, finish: true });
+  this.postMessage({ batch: [], finish: true });
 }
 
 class QueryTextEditor extends React.Component<
@@ -633,7 +633,7 @@ class QueryTextEditor extends React.Component<
     return (
       <IconButton
         size="small"
-        onClick={_ => {
+        onClick={() => {
           const query = this.editor.getValue();
           copy(query.trim());
           this.props.openSnackbar({

--- a/jupyterlab_bigquery/src/components/shared/bq_table.tsx
+++ b/jupyterlab_bigquery/src/components/shared/bq_table.tsx
@@ -191,7 +191,7 @@ export class BQTable extends React.Component<Props, State> {
     const fields = ['Row', ...this.props.fields];
 
     return (
-      <>
+      <div>
         <div className={localStyles.scrollable}>
           <Table
             size="small"
@@ -239,7 +239,7 @@ export class BQTable extends React.Component<Props, State> {
             component="div"
           />
         )}
-      </>
+      </div>
     );
   }
 }


### PR DESCRIPTION
This was causing an error in the BQTable render method where each row is expected to be an array.