### PR TITLE
Fix Cloud Function deployment issue by enabling Cloud Build

### DIFF
--- a/jupyterlab_gcpscheduler/src/components/initialization/__snapshots__/initializer.spec.tsx.snap
+++ b/jupyterlab_gcpscheduler/src/components/initialization/__snapshots__/initializer.spec.tsx.snap
@@ -50,6 +50,15 @@ exports[`Initializer Fails to create resource 1`] = `
           Object {
             "enabled": true,
             "service": Object {
+              "documentation": "https://cloud.google.com/cloud-build/",
+              "endpoint": "cloudbuild.googleapis.com",
+              "isOptional": true,
+              "name": "Cloud Build API",
+            },
+          },
+          Object {
+            "enabled": true,
+            "service": Object {
               "documentation": "https://cloud.google.com/functions/",
               "endpoint": "cloudfunctions.googleapis.com",
               "isOptional": true,
@@ -99,6 +108,15 @@ exports[`Initializer Fails to create resource 1`] = `
                 "endpoint": "cloudscheduler.googleapis.com",
                 "isOptional": true,
                 "name": "Cloud Scheduler API",
+              },
+            },
+            Object {
+              "enabled": true,
+              "service": Object {
+                "documentation": "https://cloud.google.com/cloud-build/",
+                "endpoint": "cloudbuild.googleapis.com",
+                "isOptional": true,
+                "name": "Cloud Build API",
               },
             },
             Object {
@@ -184,6 +202,15 @@ exports[`Initializer Fails to enable services 1`] = `
           Object {
             "enabled": false,
             "service": Object {
+              "documentation": "https://cloud.google.com/cloud-build/",
+              "endpoint": "cloudbuild.googleapis.com",
+              "isOptional": true,
+              "name": "Cloud Build API",
+            },
+          },
+          Object {
+            "enabled": false,
+            "service": Object {
               "documentation": "https://cloud.google.com/functions/",
               "endpoint": "cloudfunctions.googleapis.com",
               "isOptional": true,
@@ -232,6 +259,15 @@ exports[`Initializer Fails to enable services 1`] = `
                 "endpoint": "cloudscheduler.googleapis.com",
                 "isOptional": true,
                 "name": "Cloud Scheduler API",
+              },
+            },
+            Object {
+              "enabled": false,
+              "service": Object {
+                "documentation": "https://cloud.google.com/cloud-build/",
+                "endpoint": "cloudbuild.googleapis.com",
+                "isOptional": true,
+                "name": "Cloud Build API",
               },
             },
             Object {
@@ -400,6 +436,15 @@ exports[`Initializer Renders with initialization content 1`] = `
           Object {
             "enabled": false,
             "service": Object {
+              "documentation": "https://cloud.google.com/cloud-build/",
+              "endpoint": "cloudbuild.googleapis.com",
+              "isOptional": true,
+              "name": "Cloud Build API",
+            },
+          },
+          Object {
+            "enabled": false,
+            "service": Object {
               "documentation": "https://cloud.google.com/functions/",
               "endpoint": "cloudfunctions.googleapis.com",
               "isOptional": true,
@@ -448,6 +493,15 @@ exports[`Initializer Renders with initialization content 1`] = `
                 "endpoint": "cloudscheduler.googleapis.com",
                 "isOptional": true,
                 "name": "Cloud Scheduler API",
+              },
+            },
+            Object {
+              "enabled": false,
+              "service": Object {
+                "documentation": "https://cloud.google.com/cloud-build/",
+                "endpoint": "cloudbuild.googleapis.com",
+                "isOptional": true,
+                "name": "Cloud Build API",
               },
             },
             Object {
@@ -562,6 +616,15 @@ exports[`Initializer Renders with initialization content for immediate runs only
                 "endpoint": "cloudscheduler.googleapis.com",
                 "isOptional": true,
                 "name": "Cloud Scheduler API",
+              },
+            },
+            Object {
+              "enabled": false,
+              "service": Object {
+                "documentation": "https://cloud.google.com/cloud-build/",
+                "endpoint": "cloudbuild.googleapis.com",
+                "isOptional": true,
+                "name": "Cloud Build API",
               },
             },
             Object {

--- a/jupyterlab_gcpscheduler/src/components/initialization/__snapshots__/service_statuses.spec.tsx.snap
+++ b/jupyterlab_gcpscheduler/src/components/initialization/__snapshots__/service_statuses.spec.tsx.snap
@@ -44,6 +44,16 @@ exports[`ServiceStatuses Renders with all disabled 1`] = `
     </div>
     <div
       className="serviceStatusItem_f7gbs7g"
+      key="cloudbuild.googleapis.com"
+    >
+      <WithStyles(CloseIcon) />
+      <LearnMoreLink
+        href="https://cloud.google.com/cloud-build/"
+        text="Cloud Build API"
+      />
+    </div>
+    <div
+      className="serviceStatusItem_f7gbs7g"
       key="cloudfunctions.googleapis.com"
     >
       <WithStyles(CloseIcon) />
@@ -100,6 +110,16 @@ exports[`ServiceStatuses Renders with all enabled 1`] = `
     </div>
     <div
       className="serviceStatusItem_f7gbs7g"
+      key="cloudbuild.googleapis.com"
+    >
+      <WithStyles(CheckIcon) />
+      <LearnMoreLink
+        href="https://cloud.google.com/cloud-build/"
+        text="Cloud Build API"
+      />
+    </div>
+    <div
+      className="serviceStatusItem_f7gbs7g"
       key="cloudfunctions.googleapis.com"
     >
       <WithStyles(CheckIcon) />
@@ -152,6 +172,16 @@ exports[`ServiceStatuses Renders with error 1`] = `
       <LearnMoreLink
         href="https://cloud.google.com/scheduler"
         text="Cloud Scheduler API"
+      />
+    </div>
+    <div
+      className="serviceStatusItem_f7gbs7g"
+      key="cloudbuild.googleapis.com"
+    >
+      <WithStyles(CloseIcon) />
+      <LearnMoreLink
+        href="https://cloud.google.com/cloud-build/"
+        text="Cloud Build API"
       />
     </div>
     <div
@@ -213,6 +243,16 @@ exports[`ServiceStatuses Renders with pending activation 1`] = `
       <LearnMoreLink
         href="https://cloud.google.com/scheduler"
         text="Cloud Scheduler API"
+      />
+    </div>
+    <div
+      className="serviceStatusItem_f7gbs7g"
+      key="cloudbuild.googleapis.com"
+    >
+      <WithStyles(CloseIcon) />
+      <LearnMoreLink
+        href="https://cloud.google.com/cloud-build/"
+        text="Cloud Build API"
       />
     </div>
     <div

--- a/jupyterlab_gcpscheduler/src/components/initialization/initializer.spec.tsx
+++ b/jupyterlab_gcpscheduler/src/components/initialization/initializer.spec.tsx
@@ -182,6 +182,7 @@ describe('Initializer', () => {
       'storage-api.googleapis.com',
       'ml.googleapis.com',
       'cloudscheduler.googleapis.com',
+      'cloudbuild.googleapis.com',
       'cloudfunctions.googleapis.com',
     ]);
     expect(mockCreateBucket).toHaveBeenCalled();
@@ -225,6 +226,7 @@ describe('Initializer', () => {
       'storage-api.googleapis.com',
       'ml.googleapis.com',
       'cloudscheduler.googleapis.com',
+      'cloudbuild.googleapis.com',
       'cloudfunctions.googleapis.com',
     ]);
     expect(mockCreateBucket).not.toHaveBeenCalled();
@@ -270,6 +272,7 @@ describe('Initializer', () => {
       'storage-api.googleapis.com',
       'ml.googleapis.com',
       'cloudscheduler.googleapis.com',
+      'cloudbuild.googleapis.com',
       'cloudfunctions.googleapis.com',
     ]);
     expect(mockCreateBucket).toHaveBeenCalled();

--- a/jupyterlab_gcpscheduler/src/service/project_state.spec.ts
+++ b/jupyterlab_gcpscheduler/src/service/project_state.spec.ts
@@ -72,6 +72,7 @@ describe('ProjectStateService', () => {
               { serviceName: 'storage-api.googleapis.com' },
               { serviceName: 'cloudscheduler.googleapis.com' },
               { serviceName: 'ml.googleapis.com' },
+              { serviceName: 'cloudbuild.googleapis.com' },
               { serviceName: 'cloudfunctions.googleapis.com' },
             ],
           });
@@ -203,6 +204,7 @@ describe('ProjectStateService', () => {
             services: [
               { serviceName: 'storage-api.googleapis.com' },
               { serviceName: 'cloudscheduler.googleapis.com' },
+              { serviceName: 'cloudbuild.googleapis.com' },
               { serviceName: 'ml.googleapis.com' },
             ],
           });

--- a/jupyterlab_gcpscheduler/src/service/project_state.ts
+++ b/jupyterlab_gcpscheduler/src/service/project_state.ts
@@ -100,8 +100,8 @@ const RESOURCE_MANAGER = 'https://cloudresourcemanager.googleapis.com/v1';
 const BUCKET_CREATE_PERMISSION = 'storage.buckets.create';
 const OBJECT_CREATE_PERMISSION = 'storage.objects.create';
 
-// Static list of required GCP services
-const REQUIRED_SERVICES: ReadonlyArray<Service> = [
+// Static list of GCP services used by the extension
+const SERVICES: ReadonlyArray<Service> = [
   {
     name: 'Cloud Storage API',
     endpoint: 'storage-api.googleapis.com',
@@ -118,6 +118,12 @@ const REQUIRED_SERVICES: ReadonlyArray<Service> = [
     name: 'Cloud Scheduler API',
     endpoint: 'cloudscheduler.googleapis.com',
     documentation: 'https://cloud.google.com/scheduler',
+    isOptional: true,
+  },
+  {
+    name: 'Cloud Build API',
+    endpoint: 'cloudbuild.googleapis.com',
+    documentation: 'https://cloud.google.com/cloud-build/',
     isOptional: true,
   },
   {
@@ -372,7 +378,7 @@ export class ProjectStateService {
       const enabledServices = new Set(
         response.result.services.map(m => m.serviceName)
       );
-      return REQUIRED_SERVICES.map(service => ({
+      return SERVICES.map(service => ({
         service,
         enabled: enabledServices.has(service.endpoint),
       }));

--- a/jupyterlab_gcpscheduler/src/test_helpers.ts
+++ b/jupyterlab_gcpscheduler/src/test_helpers.ts
@@ -61,6 +61,15 @@ export function getProjectState(): ProjectState {
       {
         enabled: false,
         service: {
+          name: 'Cloud Build API',
+          endpoint: 'cloudbuild.googleapis.com',
+          documentation: 'https://cloud.google.com/cloud-build/',
+          isOptional: true,
+        },
+      },
+      {
+        enabled: false,
+        service: {
           name: 'Cloud Functions API',
           endpoint: 'cloudfunctions.googleapis.com',
           documentation: 'https://cloud.google.com/functions/',


### PR DESCRIPTION
Currently, users trying to initialize the Scheduler get an error message
![6SEnySUUShJKxbL](https://user-images.githubusercontent.com/6835846/99095345-0644c800-25a3-11eb-8a2b-4d735b5f9dfd.png)
 when deploying the Cloud Function. Unfortunately,  they are unable to proceed without manually enabling the Cloud Build API, deleting the Cloud Function, and then retrying the initialization steps.

This fix explicitly adds the Cloud Build API as a requirement when enabling the Scheduler for recurring runs.
![5LG9nWrQX2SHuha](https://user-images.githubusercontent.com/6835846/99095538-3ee4a180-25a3-11eb-87d0-ee41dc79fa17.png)
