### PR TITLE
Revert google-cloud-bigquery to 1.26.1

### DIFF
--- a/jupyterlab_bigquery/jupyterlab_bigquery/details_handler/service.py
+++ b/jupyterlab_bigquery/jupyterlab_bigquery/details_handler/service.py
@@ -10,7 +10,7 @@ from multiprocessing import Pool
 
 from google.cloud import bigquery
 from google.cloud.bigquery.enums import SqlTypeNames, StandardSqlDataTypes
-from google.cloud.bigquery_v2 import Model
+from google.cloud.bigquery_v2.gapic.enums import Model
 from google.protobuf.wrappers_pb2 import BoolValue, DoubleValue
 from google.api_core.client_info import ClientInfo
 from jupyterlab_bigquery.version import VERSION

--- a/jupyterlab_bigquery/setup.py
+++ b/jupyterlab_bigquery/setup.py
@@ -52,7 +52,7 @@ setup(
     install_requires=[
         "google-cloud-storage>=1.24.1",
         "jupyterlab~=1.2.0",
-        "google-cloud-bigquery~=2.4.0",
+        "google-cloud-bigquery~=1.26.1",
         "gcp_jupyterlab_shared>=1.0.0",
         "google-cloud-datacatalog~=1.0.0",
         "ipywidgets>=7.5.1",


### PR DESCRIPTION
This change aligns the version of google-cloud-bigquery installed with the extension to AI Platform DLVM version and prevents errors on startup.