### PR TITLE
Fix scripts to resolve presubmit issue

### DIFF
--- a/scripts/build_jupyterlab.sh
+++ b/scripts/build_jupyterlab.sh
@@ -20,7 +20,7 @@ SCRIPTS_DIR=$(realpath $(dirname $0))
 RUN_PYTHON_TESTS=$SCRIPTS_DIR/run_python_tests.sh
 
 . $SCRIPTS_DIR/common.sh
-echo ${LAB_EXTENSION_PACKAGES[@]}
+echo ${RELEASED_LAB_EXTENSION_PACKAGES[@]}
 
 echo "============= Linking gcp_jupyterlab_shared ============="
 pushd shared
@@ -29,7 +29,7 @@ popd
 echo "============= Finished linking gcp_jupyterlab_shared ============="
 echo
 
-for p in ${LAB_EXTENSION_PACKAGES[@]} ; do
+for p in ${RELEASED_LAB_EXTENSION_PACKAGES[@]} ; do
   echo "============= Installing $p ============="
   pushd $p
   jupyter labextension install . --no-build

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -36,3 +36,11 @@ LAB_EXTENSION_PACKAGES=(
   jupyterlab_gitsync
   jupyterlab_ucaip
 )
+
+RELEASED_LAB_EXTENSION_PACKAGES=(
+  jupyterlab_bigquery
+  jupyterlab_vizier
+  jupyterlab_hwconfig
+  jupyterlab_gcpscheduler
+  jupyterlab_gcsfilebrowser
+)


### PR DESCRIPTION
- The root causes appears to be an issue with Webpack transpiling the `highlight.js` module which is an indirect dependency of the uCAIP extension.
- Because this is not currently being offered for automated installation, we'll remove this temporarily from the `build_jupyterlab.sh` script.