### PR TITLE
Order executions and schedules by name

### DIFF
--- a/jupyterlab_gcpscheduler/src/service/gcp.spec.ts
+++ b/jupyterlab_gcpscheduler/src/service/gcp.spec.ts
@@ -408,7 +408,7 @@ describe('GcpService', () => {
       });
       expect(mockSubmit).toHaveBeenCalledWith({
         path: `${NOTEBOOKS_API_BASE}/projects/test-project/locations/-/executions`,
-        params: { filter: '' },
+        params: { filter: '', orderBy: 'name desc' },
       });
     });
 
@@ -423,7 +423,7 @@ describe('GcpService', () => {
       expect(executions).toEqual({ executions: [], pageToken: undefined });
       expect(mockSubmit).toHaveBeenCalledWith({
         path: `${NOTEBOOKS_API_BASE}/projects/test-project/locations/-/executions`,
-        params: { filter: '' },
+        params: { filter: '', orderBy: 'name desc' },
       });
     });
 
@@ -434,7 +434,7 @@ describe('GcpService', () => {
       expect(executions).toEqual({ executions: [], pageToken: undefined });
       expect(mockSubmit).toHaveBeenCalledWith({
         path: `${NOTEBOOKS_API_BASE}/projects/test-project/locations/-/executions`,
-        params: { filter: '' },
+        params: { filter: '', orderBy: 'name desc' },
       });
     });
 
@@ -456,6 +456,7 @@ describe('GcpService', () => {
           filter: '',
           pageSize: '10',
           pageToken: 'abc123',
+          orderBy: 'name desc',
         },
       });
     });
@@ -483,6 +484,7 @@ describe('GcpService', () => {
           filter: '',
           pageSize: '10',
           pageToken: 'abc123',
+          orderBy: 'name desc',
         },
       });
     });
@@ -521,13 +523,14 @@ describe('GcpService', () => {
       });
       expect(mockSubmit).toHaveBeenCalledWith({
         path: `${NOTEBOOKS_API_BASE}/projects/test-project/locations/-/schedules`,
-        params: {},
+        params: { orderBy: 'name desc' },
       });
       expect(mockSubmit).toHaveBeenCalledWith({
         path: `${NOTEBOOKS_API_BASE}/projects/test-project/locations/-/executions`,
         params: {
           pageSize: '1',
           filter: 'execution_template.labels.schedule_id="schedule1"',
+          orderBy: 'name desc',
         },
       });
       expect(mockSubmit).toHaveBeenCalledWith({
@@ -535,6 +538,7 @@ describe('GcpService', () => {
         params: {
           pageSize: '1',
           filter: 'execution_template.labels.schedule_id="schedule2"',
+          orderBy: 'name desc',
         },
       });
     });
@@ -550,7 +554,7 @@ describe('GcpService', () => {
       expect(schedules).toEqual({ schedules: [], pageToken: undefined });
       expect(mockSubmit).toHaveBeenCalledWith({
         path: `${NOTEBOOKS_API_BASE}/projects/test-project/locations/-/schedules`,
-        params: {},
+        params: { orderBy: 'name desc' },
       });
     });
 
@@ -561,7 +565,7 @@ describe('GcpService', () => {
       expect(schedules).toEqual({ schedules: [], pageToken: undefined });
       expect(mockSubmit).toHaveBeenCalledWith({
         path: `${NOTEBOOKS_API_BASE}/projects/test-project/locations/-/schedules`,
-        params: {},
+        params: { orderBy: 'name desc' },
       });
     });
 
@@ -582,6 +586,7 @@ describe('GcpService', () => {
         params: {
           pageSize: '10',
           pageToken: 'abc123',
+          orderBy: 'name desc',
         },
       });
     });
@@ -608,6 +613,7 @@ describe('GcpService', () => {
         params: {
           pageSize: '10',
           pageToken: 'abc123',
+          orderBy: 'name desc',
         },
       });
     });

--- a/jupyterlab_gcpscheduler/src/service/gcp.ts
+++ b/jupyterlab_gcpscheduler/src/service/gcp.ts
@@ -232,8 +232,8 @@ export class GcpService {
     try {
       const projectId = await this.projectId;
       const params: { [k: string]: string } = { filter };
-      //TODO: uncomment when sorting works
-      //params['orderBy'] = 'createTime';
+       //TODO: change to createTime when that works
+      params['orderBy'] = 'name desc';
       if (pageSize) {
         params['pageSize'] = String(pageSize);
       }
@@ -284,8 +284,8 @@ export class GcpService {
     try {
       const projectId = await this.projectId;
       const params: { [k: string]: string } = {};
-      //TODO: uncomment when sorting works
-      //params['orderBy'] = 'createTime';
+      //TODO: change to createTime when that works
+      params['orderBy'] = 'name desc';
       if (pageSize) {
         params['pageSize'] = String(pageSize);
       }

--- a/jupyterlab_gcpscheduler/src/service/gcp.ts
+++ b/jupyterlab_gcpscheduler/src/service/gcp.ts
@@ -407,7 +407,7 @@ export class GcpService {
     try {
       const latestExecutionResponse = await this.listExecutions(
         `execution_template.labels.schedule_id="${scheduleId}"`,
-        1,
+        undefined,
         undefined
       );
       if (latestExecutionResponse.executions.length !== 0) {

--- a/jupyterlab_gcpscheduler/src/service/gcp.ts
+++ b/jupyterlab_gcpscheduler/src/service/gcp.ts
@@ -232,7 +232,7 @@ export class GcpService {
     try {
       const projectId = await this.projectId;
       const params: { [k: string]: string } = { filter };
-       //TODO: change to createTime when that works
+      //TODO: change to createTime when that works
       params['orderBy'] = 'name desc';
       if (pageSize) {
         params['pageSize'] = String(pageSize);


### PR DESCRIPTION
Adding orderBy 'name desc' to listExecutions and listSchedules so at least the order is consistent (& tests)