### PR TITLE
Run gcloud in a shell

### DIFF
--- a/jupyterlab_gcloud/jupyterlab_gcloud/config.py
+++ b/jupyterlab_gcloud/jupyterlab_gcloud/config.py
@@ -21,7 +21,7 @@ def get_gcloud_config(field):
   """Helper method that invokes the gcloud config helper."""
   p = subprocess.run(
     ['gcloud', 'config', 'config-helper', f'--format=value({field})'],
-    stdin=subprocess.DEVNULL, capture_output=True, check=True, encoding='UTF-8')
+    stdin=subprocess.DEVNULL, capture_output=True, check=True, encoding='UTF-8', shell=True)
   return p.stdout.strip()
 
 


### PR DESCRIPTION
On some platforms, the `gcloud` command is provided by a binary named something other than `gcloud` (e.g. `gcloud.com` on Windows).

For those platforms, using subprocess to run the command without the `shell=True` argument will fail because there is no file named `gcloud`.

Instead, we need to pass in the `shell=True` argument so that the call to subprocess first resolves which binary corresponds to the `gcloud` command and then runs that binary.