### PR TITLE
Update .gitmodules to remove a dead link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
 [submodule "jupyterlab_gitsync/jupyterlab_gitsync/git-sync-changes"]
 	path = jupyterlab_gitsync/jupyterlab_gitsync/git-sync-changes
 	url = https://github.com/google/git-sync-changes.git
-
-[submodule "jupyterlab_gitsync/TEST"]
-	path = jupyterlab_gitsync/TEST
-	url = git@github.com:ashleyswang/TEST.git


### PR DESCRIPTION
Remove a dead submodule link.

This seems to have been added for (manual?) testing, and as far as I can tell is not referenced anywhere in the repository.