### PR TITLE
Use the system stderr when running commands in a subprocess.

### DIFF
--- a/google-cloud-jupyter-config/setup.py
+++ b/google-cloud-jupyter-config/setup.py
@@ -19,7 +19,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
   name="google-cloud-jupyter-config",
   author="Google, Inc.",
-  version="0.0.4",
+  version="0.0.5",
   description="Jupyter configuration utilities using gcloud",
   long_description=long_description,
   long_description_content_type="text/markdown",


### PR DESCRIPTION
This allows the user to see any prompts from the command, such as when gcloud reports that the user has to (re)authenticate.