### PR TITLE
Add 'preferred_dir' attribute to 'CombinedContentsManager'

### DIFF
--- a/jupyter-gcs-contents-manager/gcs_contents_manager.py
+++ b/jupyter-gcs-contents-manager/gcs_contents_manager.py
@@ -528,6 +528,8 @@ class CombinedCheckpointsManager(GenericCheckpointsMixin, Checkpoints):
 class CombinedContentsManager(ContentsManager):
   root_dir = Unicode(config=True)
 
+  preferred_dir = Unicode("", config=True)
+
   @default('checkpoints')
   def _default_checkpoints(self):
     return CombinedCheckpointsManager(self._content_managers)


### PR DESCRIPTION

This change avoids jupyter-server startup failure due to missing `preferred_dir` attribute after [this change](https://github.com/jupyter-server/jupyter_server/commit/2ca800829c96dc60893dc83715282b7b8fd03d59#diff-72888b4a95043904b226c1aa5addc9687a1dd09706da5e59ed28be58ae5f99c9R1829) in jupyter-server
