### PR TITLE
Create a new release for the `kernels-mixer` package.

### DIFF
--- a/kernels-mixer/setup.py
+++ b/kernels-mixer/setup.py
@@ -18,7 +18,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
   name="kernels-mixer",
-  version="0.0.3",
+  version="0.0.4",
   author="Google, Inc.",
   description="Jupyter server extension that allows mixing local and remote kernels together",
   long_description=long_description,
@@ -28,7 +28,7 @@ setuptools.setup(
   packages=setuptools.find_packages(),
   python_requires=">=3.8",
   install_requires=[
-    "jupyter_server>=2.6.0",
+    "jupyter_server>=2.7.3",
     "traitlets",
     "google-cloud-jupyter-config",
   ],


### PR DESCRIPTION
The new release version is `0.0.4`.

This also updates the `jupyter-server` dependency to `>=2.7.3`.

That is so users pick up the fix for
[this issue](https://github.com/jupyter-server/jupyter_server/issues/1299)