### PR TITLE
[kernels-mixer] Report an initial kernel status on websocket connections.

### DIFF
--- a/kernels-mixer/kernels_mixer/websockets.py
+++ b/kernels-mixer/kernels_mixer/websockets.py
@@ -12,16 +12,97 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+import json
+import uuid
+
+from tornado.escape import json_decode, utf8
+
 from jupyter_server.gateway.connections import GatewayWebSocketConnection
 from jupyter_server.gateway.managers import GatewayKernelManager
 from jupyter_server.services.kernels.connection.base import BaseKernelWebsocketConnection
 from jupyter_server.services.kernels.connection.channels import ZMQChannelsWebsocketConnection
 
+class StartingReportingWebsocketConnection(GatewayWebSocketConnection):
+    """Extension of GatewayWebSocketConnection that reports a starting status on connection.
+
+    The purpose of this class is to bridge the time period between when the websocket
+    connection from the client is created and the websocket connection to the Gateway
+    server is created.
+
+    During that time, the JupyterLab UI believes that it is connected to the running
+    kernel, but it has not yet received any status messages from the kernel, so it will
+    display a kernel status of "Unknown".
+
+    That "Unknown" status is not very helpful to users because they have no idea why
+    the kernel status is unknown and have no indication that something is still
+    happening under the hood.
+
+    To improve that, we report a provisional status as soon as the client connection
+    is established. This provisional status will be replaced by the real status
+    reported by the kernel as soon as the backend kernel connection is established.
+
+    The only kernel statuses supported by the JupyterLab UI are "starting", "idle",
+    "busy","restarting", and "dead".
+
+    Of those, the "starting" message is the closest match to what is going on, so
+    we use that one.
+
+    However, the "starting" message is only supposed to be reported once, so we
+    also intercept any "starting" messages received from the kernel and discard
+    them, as we know we will have already reported this status.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    async def connect(self):
+        # The kernel message format is defined
+        # [here](https://jupyter-client.readthedocs.io/en/latest/messaging.html#general-message-format).
+        status_message_id = str(uuid.uuid4())
+        status_message = {
+            "header": {
+                "msg_id": status_message_id,
+                "session": self.kernel_id,
+                "username": "username",
+                "date": datetime.datetime.utcnow().isoformat(),
+                "msg_type": "status",
+                "version": "5.3",
+            },
+            "parent_header": {},
+            "metadata": {},
+            "msg_id": status_message_id,
+            "msg_type": "status",
+            "channel": "iopub",
+            "content": {
+                "execution_state": "starting",
+            },
+            "buffers": [],
+        }
+        super().handle_outgoing_message(json.dumps(status_message))
+        return await super().connect()
+
+    def is_starting_message(self, incoming_msg):
+        try:
+            msg = json_decode(utf8(incoming_msg))
+            if msg.get("content", {}).get("execution_state", "") == "starting":
+                return True
+        except Exception as ex:
+            pass
+        return False
+
+    def handle_outgoing_message(self, incoming_msg, *args, **kwargs):
+        if self.is_starting_message(incoming_msg):
+            # We already sent a starting message, so drop this one.
+            return
+        return super().handle_outgoing_message(incoming_msg, *args, **kwargs)
+
+
 class DelegatingWebsocketConnection(BaseKernelWebsocketConnection):
     """Implementation of BaseKernelWebsocketConnection that delegates to another connection.
 
     If the parent KernelManager instance is for a remote kernel (i.e. it is a
-    GatewayKernelManager), then the delegate is an instance of GatewayWebSocketConnection.
+    GatewayKernelManager), then the delegate is an instance of
+    StartingReportingWebsocketConnection, which extends GatewayWebSocketConnection.
 
     Otherwise, it is an instance of ZMQChannelsWebsocketConnection.
     """
@@ -30,7 +111,7 @@ class DelegatingWebsocketConnection(BaseKernelWebsocketConnection):
         super().__init__(*args, **kwargs)
         delegate_class = ZMQChannelsWebsocketConnection
         if self.kernel_manager.is_remote:
-            delegate_class = GatewayWebSocketConnection
+            delegate_class = StartingReportingWebsocketConnection
         self.delegate = delegate_class(
             parent=self.kernel_manager.delegate,
             websocket_handler=self.websocket_handler,

--- a/kernels-mixer/kernels_mixer/websockets.py
+++ b/kernels-mixer/kernels_mixer/websockets.py
@@ -43,7 +43,7 @@ class StartingReportingWebsocketConnection(GatewayWebSocketConnection):
     reported by the kernel as soon as the backend kernel connection is established.
 
     The only kernel statuses supported by the JupyterLab UI are "starting", "idle",
-    "busy","restarting", and "dead".
+    "busy", "restarting", and "dead".
 
     Of those, the "starting" message is the closest match to what is going on, so
     we use that one.

--- a/kernels-mixer/setup.py
+++ b/kernels-mixer/setup.py
@@ -18,7 +18,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
   name="kernels-mixer",
-  version="0.0.6",
+  version="0.0.7",
   author="Google, Inc.",
   description="Jupyter server extension that allows mixing local and remote kernels together",
   long_description=long_description,


### PR DESCRIPTION
This provides more visibility to the user for the scenario that a client connection from the user has been established, but the Gateway connection to the backend kernel is still starting.