### PR TITLE
[kernels-mixer] Ignore errors listing remote kernels

### DIFF
--- a/kernels-mixer/kernels_mixer/kernels.py
+++ b/kernels-mixer/kernels_mixer/kernels.py
@@ -50,7 +50,11 @@ class MixingMappingKernelManager(AsyncMappingKernelManager):
             kernel_spec_manager=self.kernel_spec_manager.remote_manager)
 
     def list_kernels(self):
-        run_sync(self.remote_manager.list_kernels)()
+        try:
+            run_sync(self.remote_manager.list_kernels)()
+        except Exception as ex:
+            self.log.exception('Failure listing remote kernels: %s', ex)
+            # Ignore the exception listing remote kernels, so that local kernels are still usable.
         return super().list_kernels()
 
     def kernel_model(self, kernel_id):

--- a/kernels-mixer/setup.py
+++ b/kernels-mixer/setup.py
@@ -18,7 +18,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
   name="kernels-mixer",
-  version="0.0.9",
+  version="0.0.10",
   author="Google, Inc.",
   description="Jupyter server extension that allows mixing local and remote kernels together",
   long_description=long_description,


### PR DESCRIPTION
This makes the code for listing kernels consistent with the code for listing kernelspecs, which ignores remote failures so that local kernels remain usable.