### PR TITLE
[kernels-mixer] Blocking logic cleanup/fixes.

### DIFF
--- a/kernels-mixer/kernels_mixer/kernels_test.py
+++ b/kernels-mixer/kernels_mixer/kernels_test.py
@@ -168,7 +168,7 @@ class TestKernelModel(unittest.TestCase):
 
     def test_remote_kernel_model(self):
         remote_kernel_id = run_sync(self.mkm.start_kernel)(kernel_name=remote_kernel)
-        self.mkm.list_kernels()
+        run_sync(self.mkm.list_kernels)()
         remote_kernel_model = self.mkm.kernel_model(remote_kernel_id)
         self.assertEqual(remote_kernel_model["id"], remote_kernel_id)
         self.assertEqual(remote_kernel_model["name"], remote_kernel)

--- a/kernels-mixer/setup.py
+++ b/kernels-mixer/setup.py
@@ -18,7 +18,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
   name="kernels-mixer",
-  version="0.0.10",
+  version="0.0.11",
   author="Google, Inc.",
   description="Jupyter server extension that allows mixing local and remote kernels together",
   long_description=long_description,


### PR DESCRIPTION
The `MixingMappingKernelManager` and `MixingKernelSpecManager` classes have to bridge
between blocking and asynchronous versions of their underlying classes (blocking for
local kernels and asynchronous for remote kernels).

To do that bridging, they have to expose synchronous methods to callers that do
not support/expect the called methods to be asynchronous.

Previously, the `kernels-mixer` package tried to play it safe by making all of
the methods that have to bridge this difference be synchronous.

However, it turns out that approach causes issues with Tornado's event loop,
[which is single-threaded](https://www.tornadoweb.org/en/stable/guide/async.html#asynchronous-and-non-blocking-i-o).

I looked through the code for both `jupyter_server` and the underlying
`jupyter_client`, and it turns out that client code for all of these methods
actually supports the methods being asynchronous, *except* for client code
that calls into the kernel manager's `kernel_model` method.

Additionally, that one method is OK it block, because even in the case of
remote kernels it does not actually issue any network requests, and instead
only operates on in memory data.

As such, the one method that actually *needs* to be synchronous is also one
that is safe to make so.

Accordingly, this change keeps only that one method as is, and replaces all
of the *other* synchronous methods with corresponding asynchronous ones.

This should both fix the Tornado event loop lockup while still preserving
the correct behavior of all of the logic within the Jupyter server.