### PR TITLE
[google-cloud-jupyter-config] Fix async test coverage and bugs this exposed.

### DIFF
--- a/google-cloud-jupyter-config/google/cloud/jupyter_config/config_test.py
+++ b/google-cloud-jupyter-config/google/cloud/jupyter_config/config_test.py
@@ -16,6 +16,7 @@ import os
 import unittest
 
 from google.cloud.jupyter_config.config import (
+    async_run_gcloud_subcommand,
     async_get_gcloud_config,
     gcp_account,
     gcp_credentials,
@@ -23,10 +24,9 @@ from google.cloud.jupyter_config.config import (
     gcp_region,
     clear_gcloud_cache,
 )
-import pytest
 
 
-class TestConfig(unittest.TestCase):
+class TestConfig(unittest.IsolatedAsyncioTestCase):
     _mock_cloudsdk_variables = {
         "CLOUDSDK_AUTH_ACCESS_TOKEN": "example-token",
         "CLOUDSDK_CORE_ACCOUNT": "example-account",
@@ -70,7 +70,10 @@ class TestConfig(unittest.TestCase):
         os.environ["CLOUDSDK_DATAPROC_REGION"] = "should-not-be-used"
         self.assertEqual(gcp_region(), "example-region")
 
-    @pytest.mark.asyncio
+    async def test_async_run_gcloud_subcommand(self):
+        test_project = await async_run_gcloud_subcommand("config get core/project")
+        self.assertEqual(test_project, "example-project")
+
     async def test_async_gcloud_config(self):
         test_account = await async_get_gcloud_config(
             "configuration.properties.core.account"

--- a/google-cloud-jupyter-config/setup.py
+++ b/google-cloud-jupyter-config/setup.py
@@ -19,7 +19,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="google-cloud-jupyter-config",
     author="Google, Inc.",
-    version="0.0.9",
+    version="0.0.10",
     description="Jupyter configuration utilities using gcloud",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -31,8 +31,5 @@ setuptools.setup(
         "cachetools",
         "jupyter_server>=2.4.0",
         "traitlets",
-    ],
-    tests_require=[
-        "pytest-asyncio",
     ],
 )


### PR DESCRIPTION
The previous version of the async test case did not actually run to the end because we never awaited the result. That meant that we weren't actually testing the async behavior the way we thought we were and there were hidden bugs in it that were not caught by our tests.

This change fixes the test so that async test cases actually run end to end, and also fixes the preexisting bugs that were caught by the fixed tests.