### PR TITLE
[google-cloud-jupyter-config] Replace gcloud CLI subprocess calls with google-auth Python SDK

### DIFF
--- a/google-cloud-jupyter-config/conftest.py
+++ b/google-cloud-jupyter-config/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import configparser
 import os
-import sys
+import tempfile
 
 import pytest
-
-from google.cloud.jupyter_config.config import clear_gcloud_cache
 
 
 pytest_plugins = ['pytest_jupyter.jupyter_server']
@@ -35,31 +34,28 @@ def jp_server_config(jp_server_config):
 
 
 @pytest.fixture
-def mock_gcloud_env():
-    _mock_cloudsdk_variables = {
-        "CLOUDSDK_AUTH_ACCESS_TOKEN": "example-token",
-        "CLOUDSDK_CORE_ACCOUNT": "example-account",
-        "CLOUDSDK_CORE_PROJECT": "example-project",
-        "CLOUDSDK_DATAPROC_REGION": "example-region",
-        # Make sure that gcloud uses the same python environment as the test to
-        # avoid issues caused by conflicting versions.
-        "CLOUDSDK_PYTHON": sys.executable,
+def mock_gcloud_properties(monkeypatch, tmp_path):
+    """Create a fake gcloud config directory with properties."""
+    config_dir = tmp_path / "gcloud"
+    config_dir.mkdir()
+
+    # Write active_config
+    (config_dir / "active_config").write_text("default")
+
+    # Write config file
+    configs_dir = config_dir / "configurations"
+    configs_dir.mkdir()
+    config = configparser.ConfigParser()
+    config["core"] = {
+        "account": "example-account",
+        "project": "example-project",
     }
+    config["dataproc"] = {
+        "region": "example-region",
+    }
+    config_file = configs_dir / "config_default"
+    with open(config_file, "w") as f:
+        config.write(f)
 
-    # First override the existing environment with our mock variables
-    original_cloudsdk_variables = {}
-    for key in os.environ:
-        if key.startswith("CLOUDSDK_"):
-            original_cloudsdk_variables[key] = os.environ[key]
-    for key in _mock_cloudsdk_variables:
-        os.environ[key] = _mock_cloudsdk_variables[key]
-    clear_gcloud_cache()
-
-    # Yield the modified environment
-    yield os.environ
-
-    # Cleanup the environment by resetting any modified variables
-    for key in _mock_cloudsdk_variables:
-        del os.environ[key]
-    for key in original_cloudsdk_variables:
-        os.environ[key] = original_cloudsdk_variables[key]
+    monkeypatch.setenv("CLOUDSDK_CONFIG", str(config_dir))
+    return config_dir

--- a/google-cloud-jupyter-config/google/cloud/jupyter_config/__init__.py
+++ b/google-cloud-jupyter-config/google/cloud/jupyter_config/__init__.py
@@ -14,8 +14,6 @@
 
 from jupyter_server.utils import url_path_join
 
-from google.cloud.jupyter_config.config import async_get_gcloud_config
-from google.cloud.jupyter_config.config import get_gcloud_config
 from google.cloud.jupyter_config.config import gcp_project
 from google.cloud.jupyter_config.config import gcp_region
 from google.cloud.jupyter_config.config import configure_gateway_client

--- a/google-cloud-jupyter-config/google/cloud/jupyter_config/config.py
+++ b/google-cloud-jupyter-config/google/cloud/jupyter_config/config.py
@@ -13,217 +13,110 @@
 # limitations under the License.
 
 import asyncio
-from concurrent import futures
-import datetime
+import configparser
 import json
+import os
 import re
 import subprocess
 import sys
 import tempfile
-import threading
 
-import cachetools
+import google.auth
+import google.auth.transport.requests
+from google.cloud import resourcemanager_v3
 from jupyter_server.base.handlers import APIHandler
 import tornado
 
-from google.cloud.jupyter_config.tokenrenewer import CommandTokenRenewer
+from google.cloud.jupyter_config.tokenrenewer import GoogleAuthTokenRenewer
 
 
-def run_gcloud_subcommand(subcmd):
-    """Run a specified gcloud sub-command and return its output.
+def _get_gcloud_config_path():
+    """Return the path to the gcloud CLI properties file."""
+    config_dir = os.environ.get(
+        "CLOUDSDK_CONFIG", os.path.join(os.path.expanduser("~"), ".config", "gcloud")
+    )
+    active_config = "default"
+    active_config_file = os.path.join(config_dir, "active_config")
+    if os.path.exists(active_config_file):
+        with open(active_config_file, "r") as f:
+            active_config = f.read().strip() or "default"
+    return os.path.join(config_dir, "configurations", f"config_{active_config}")
 
-    The supplied subcommand is the full command line invocation, *except* for
-    the leading `gcloud` being omitted.
 
-    e.g. `info` instead of `gcloud info`.
+def _read_gcloud_properties():
+    """Read gcloud CLI properties from the config file.
 
-    We reuse the system stderr for the command so that any prompts from gcloud
-    will be displayed to the user.
+    Returns a nested dict like {"core": {"project": "...", "account": "..."}, ...}.
     """
-    with tempfile.TemporaryFile() as t:
-        p = subprocess.run(
-            f"gcloud {subcmd}",
-            stdin=subprocess.DEVNULL,
-            stderr=sys.stderr,
-            stdout=t,
-            check=True,
-            encoding="UTF-8",
-            shell=True,
-        )
-        t.seek(0)
-        return t.read().decode("UTF-8").strip()
+    config_path = _get_gcloud_config_path()
+    parser = configparser.ConfigParser()
+    parser.read(config_path)
+    result = {}
+    for section in parser.sections():
+        result[section] = dict(parser.items(section))
+    return result
 
 
-async def _run_gcloud_subcommand_via_process_pool_executor(subcmd):
-    loop = asyncio.get_running_loop()
-    with futures.ProcessPoolExecutor() as pool:
-        return await loop.run_in_executor(pool, run_gcloud_subcommand, subcmd)
-
-
-async def async_run_gcloud_subcommand(subcmd):
-    """Run a specified gcloud sub-command and return its output.
-
-    The supplied subcommand is the full command line invocation, *except* for
-    the leading `gcloud` being omitted.
-
-    e.g. `info` instead of `gcloud info`.
-
-    We reuse the system stderr for the command so that any prompts from gcloud
-    will be displayed to the user.
-    """
-
-    # Jupyter forces the use of a SelectorEventLoop on Windows, which does not
-    # support subprocesses. To work around that, on Windows (and *only* on
-    # Windows), we run the gcloud command synchronously inside of a separate
-    # process rather than asynchronously in the main process.
-    #
-    # This is a heavy-handed approach, but it ensures that our calls to gcloud
-    # do not block the Tornado request serving thread.
-    #
-    # See https://github.com/jupyter-server/jupyter_server/issues/1587 for
-    # more details.
-    if sys.platform.startswith("win"):
-        return await _run_gcloud_subcommand_via_process_pool_executor(subcmd)
-
-    with tempfile.TemporaryFile() as t:
-        p = await asyncio.create_subprocess_shell(
-            f"gcloud {subcmd}",
-            stdin=subprocess.DEVNULL,
-            stderr=sys.stderr,
-            stdout=t,
-        )
-        await p.wait()
-        if p.returncode != 0:
-            raise subprocess.CalledProcessError(p.returncode, None, None, None)
-        t.seek(0)
-        return t.read().decode("UTF-8").strip()
-
-
-@cachetools.cached(
-    cache=cachetools.TTLCache(maxsize=1024, ttl=(20 * 60)), lock=threading.Lock()
-)
-def cached_gcloud_subcommand(subcmd):
-    return run_gcloud_subcommand(subcmd)
-
-
-def clear_gcloud_cache():
-    """Clear the TTL cache used to cache gcloud subcommand results."""
-    cached_gcloud_subcommand.cache_clear()
-
-
-def _get_config_field(config, field):
-    subconfig = config
-    for path_part in field.split("."):
-        if path_part:
-            subconfig = subconfig.get(path_part, {})
-    return subconfig
-
-
-def get_gcloud_config(field):
-    """Helper method that invokes the gcloud config helper.
-
-    Invoking gcloud commands is a very heavyweight process, so the config is
-    cached for up to 20 minutes.
-
-    The config is generated with a minimum credential expiry of 30 minutes, so
-    that we can ensure that the caller can use the cached credentials for at
-    least ~10 minutes even if the cache entry is about to expire.
-
-    Args:
-        field: A period-separated search path for the config value to return.
-               For example, 'configuration.properties.core.project'
-    Returns:
-        A JSON object whose type depends on the search path for the field within
-        the gcloud config.
-
-        For example, if the field is `configuration.properties.core.project`,
-        then the return value will be a string. In comparison, if the field
-        is `configuration.properties.core`, then the return value will be a
-        dictionary containing a field named `project` with a string value.
-    """
-    subcommand = "config config-helper --min-expiry=30m --format=json"
-    cached_config_str = cached_gcloud_subcommand(subcommand)
-    cached_config = json.loads(cached_config_str)
-    return _get_config_field(cached_config, field)
-
-
-async def async_get_gcloud_config(field):
-    """Async helper method that invokes the gcloud config helper.
-
-    This is like `get_gcloud_config` but does not block on the underlying
-    gcloud invocation when there is a cache miss.
-
-    Args:
-        field: A period-separated search path for the config value to return.
-               For example, 'configuration.properties.core.project'
-    Returns:
-        An awaitable that resolves to a JSON object with a type depending on
-        the search path for the field within the gcloud config.
-
-        For example, if the field is `configuration.properties.core.project`,
-        then the JSON object will be a string. In comparison, if the field
-        is `configuration.properties.core`, then it will be a dictionary
-        containing a field named `project` with a string value.
-    """
-    subcommand = "config config-helper --min-expiry=30m --format=json"
-    with cached_gcloud_subcommand.cache_lock:
-        if subcommand in cached_gcloud_subcommand.cache:
-            cached_config_str = cached_gcloud_subcommand.cache[subcommand]
-            cached_config = json.loads(cached_config_str)
-            return _get_config_field(cached_config, field)
-
-    out = await async_run_gcloud_subcommand(subcommand)
-    with cached_gcloud_subcommand.cache_lock:
-        cached_gcloud_subcommand.cache[subcommand] = out
-    config = json.loads(out)
-    return _get_config_field(config, field)
+def _get_credentials():
+    """Get google-auth credentials with cloud-platform scope."""
+    credentials, project = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"]
+    )
+    return credentials, project
 
 
 def gcp_account():
-    """Helper method to get the project configured through gcloud"""
-    return get_gcloud_config("configuration.properties.core.account")
+    """Get the account configured through gcloud properties."""
+    props = _read_gcloud_properties()
+    return props.get("core", {}).get("account", "")
 
 
 def gcp_credentials():
-    """Helper method to get the project configured through gcloud"""
-    return get_gcloud_config("credential.access_token")
+    """Get a valid access token using Application Default Credentials."""
+    credentials, _ = _get_credentials()
+    request = google.auth.transport.requests.Request()
+    credentials.refresh(request)
+    return credentials.token
 
 
 def gcp_project():
-    """Helper method to get the project configured through gcloud"""
-    return get_gcloud_config("configuration.properties.core.project")
+    """Get the project, preferring ADC's project, falling back to gcloud properties."""
+    _, project = _get_credentials()
+    if project:
+        return project
+    props = _read_gcloud_properties()
+    return props.get("core", {}).get("project", "")
 
 
 def gcp_project_number():
-    """Helper method to get the project number for the project configured through gcloud"""
-    project = gcp_project()
-    return run_gcloud_subcommand(
-        f'projects describe {project} --format="value(projectNumber)"'
-    )
+    """Get the project number for the configured project using the Resource Manager API."""
+    project_id = gcp_project()
+    client = resourcemanager_v3.ProjectsClient()
+    project = client.get_project(name=f"projects/{project_id}")
+    # project.name is "projects/<number>"
+    return project.name.split("/")[1]
 
 
 def gcp_region():
-    """Helper method to get the project configured through gcloud"""
-    region = get_gcloud_config("configuration.properties.dataproc.region")
+    """Get the region from gcloud properties (dataproc.region or compute.region)."""
+    props = _read_gcloud_properties()
+    region = props.get("dataproc", {}).get("region", "")
     if not region:
-        region = get_gcloud_config("configuration.properties.compute.region")
+        region = props.get("compute", {}).get("region", "")
     return region
 
 
 def gcp_kernel_gateway_url():
-    """Helper method to return the kernel gateway URL for the configured project and region."""
+    """Return the kernel gateway URL for the configured project and region."""
     project = gcp_project_number()
     region = gcp_region()
     return f"https://{project}-dot-{region}.kernels.googleusercontent.com"
 
 
 def configure_gateway_client(c):
-    """Helper method for configuring the given Config object to use the GCP kernel gateway."""
+    """Configure the given Config object to use the GCP kernel gateway."""
     c.GatewayClient.url = gcp_kernel_gateway_url()
-    c.GatewayClient.gateway_token_renewer_class = CommandTokenRenewer
-    c.CommandTokenRenewer.token_command = (
-        'gcloud config config-helper --min-expiry=30m --format="value(credential.access_token)"'
-    )
+    c.GatewayClient.gateway_token_renewer_class = GoogleAuthTokenRenewer
 
     # Version 2.8.0 of the `jupyter_server` package requires the `auth_token`
     # value to be set to a non-empty value or else it will never invoke the
@@ -248,10 +141,54 @@ _allowed_property_names = re.compile("^[a-zA-Z0-9_-]+$")
 _allowed_property_values = re.compile("^[a-zA-Z0-9.:_-]+$")
 
 
+async def _async_run_gcloud_subcommand(subcmd):
+    """Run a gcloud sub-command asynchronously.
+
+    Only used for `gcloud config set` operations in PropertiesHandler.
+    """
+    if sys.platform.startswith("win"):
+        loop = asyncio.get_running_loop()
+        from concurrent import futures
+        with futures.ProcessPoolExecutor() as pool:
+            return await loop.run_in_executor(pool, _run_gcloud_subcommand, subcmd)
+
+    with tempfile.TemporaryFile() as t:
+        p = await asyncio.create_subprocess_shell(
+            f"gcloud {subcmd}",
+            stdin=subprocess.DEVNULL,
+            stderr=sys.stderr,
+            stdout=t,
+        )
+        await p.wait()
+        if p.returncode != 0:
+            raise subprocess.CalledProcessError(p.returncode, None, None, None)
+        t.seek(0)
+        return t.read().decode("UTF-8").strip()
+
+
+def _run_gcloud_subcommand(subcmd):
+    """Run a gcloud sub-command synchronously.
+
+    Only used for `gcloud config set` operations.
+    """
+    with tempfile.TemporaryFile() as t:
+        subprocess.run(
+            f"gcloud {subcmd}",
+            stdin=subprocess.DEVNULL,
+            stderr=sys.stderr,
+            stdout=t,
+            check=True,
+            encoding="UTF-8",
+            shell=True,
+        )
+        t.seek(0)
+        return t.read().decode("UTF-8").strip()
+
+
 class PropertiesHandler(APIHandler):
     @tornado.web.authenticated
     async def get(self):
-        properties = await async_get_gcloud_config("configuration.properties")
+        properties = _read_gcloud_properties()
         self.finish(json.dumps(properties))
         return
 
@@ -282,8 +219,7 @@ class PropertiesHandler(APIHandler):
         try:
             updated_properties_list = flatten_dictionary("", updated_properties)
             for k, v in updated_properties_list:
-                await async_run_gcloud_subcommand(f"config set {k} {v}")
-            clear_gcloud_cache()
+                await _async_run_gcloud_subcommand(f"config set {k} {v}")
             self.finish(json.dumps(updated_properties_list))
         except ValueError as ve:
             self.set_status(400)

--- a/google-cloud-jupyter-config/google/cloud/jupyter_config/config_test.py
+++ b/google-cloud-jupyter-config/google/cloud/jupyter_config/config_test.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 import json
-import os
+from unittest import mock
 
 import pytest
 from tornado import httpclient
 
 from google.cloud.jupyter_config.config import (
-    async_run_gcloud_subcommand,
-    async_get_gcloud_config,
     gcp_account,
     gcp_credentials,
     gcp_project,
@@ -28,51 +26,44 @@ from google.cloud.jupyter_config.config import (
 )
 
 
-def test_gcp_account(mock_gcloud_env):
-    assert gcp_account() == "example-account"
-
-    # Verify that changing the OS environment variable does not modify the cached property
-    os.environ["CLOUDSDK_CORE_ACCOUNT"] = "should-not-be-used"
+def test_gcp_account(mock_gcloud_properties):
     assert gcp_account() == "example-account"
 
 
-def test_gcp_credentials(mock_gcloud_env):
-    assert gcp_credentials() == "example-token"
-
-    # Verify that changing the OS environment variable does not modify the cached property
-    os.environ["CLOUDSDK_AUTH_ACCESS_TOKEN"] = "should-not-be-used"
-    assert gcp_credentials() == "example-token"
-
-    
-def test_gcp_project(mock_gcloud_env):
-    assert gcp_project() == "example-project"
-
-    # Verify that changing the OS environment variable does not modify the cached property
-    os.environ["CLOUDSDK_CORE_PROJECT"] = "should-not-be-used"
+def test_gcp_project(mock_gcloud_properties):
     assert gcp_project() == "example-project"
 
 
-def test_gcp_region(mock_gcloud_env):
-    assert gcp_region() == "example-region"
-
-    # Verify that changing the OS environment variable does not modify the cached property
-    os.environ["CLOUDSDK_DATAPROC_REGION"] = "should-not-be-used"
+def test_gcp_region(mock_gcloud_properties):
     assert gcp_region() == "example-region"
 
 
-async def test_async_run_gcloud_subcommand(mock_gcloud_env):
-    test_project = await async_run_gcloud_subcommand("config get core/project")
-    assert test_project == "example-project"
+@mock.patch("google.cloud.jupyter_config.config._get_credentials")
+def test_gcp_credentials(mock_get_creds):
+    mock_creds = mock.MagicMock()
+    mock_creds.token = "test-access-token"
+    mock_get_creds.return_value = (mock_creds, "test-project")
+    assert gcp_credentials() == "test-access-token"
+    mock_creds.refresh.assert_called_once()
 
 
-async def test_async_gcloud_config(mock_gcloud_env):
-    test_account = await async_get_gcloud_config(
-        "configuration.properties.core.account"
-    )
-    assert test_account == "example-account"
+@mock.patch("google.cloud.jupyter_config.config._get_credentials")
+def test_gcp_project_from_adc(mock_get_creds):
+    """Project from ADC takes priority over gcloud properties."""
+    mock_creds = mock.MagicMock()
+    mock_get_creds.return_value = (mock_creds, "adc-project")
+    assert gcp_project() == "adc-project"
 
 
-async def test_get_properties(jp_fetch, mock_gcloud_env):
+@mock.patch("google.cloud.jupyter_config.config._get_credentials")
+def test_gcp_project_falls_back_to_gcloud(mock_get_creds, mock_gcloud_properties):
+    """Falls back to gcloud properties when ADC has no project."""
+    mock_creds = mock.MagicMock()
+    mock_get_creds.return_value = (mock_creds, None)
+    assert gcp_project() == "example-project"
+
+
+async def test_get_properties(jp_fetch, mock_gcloud_properties):
     response = await jp_fetch("gcloud", "config", "properties")
     assert response.code == 200
 
@@ -82,24 +73,25 @@ async def test_get_properties(jp_fetch, mock_gcloud_env):
     assert properties["dataproc"]["region"] == "example-region"
 
 
-async def test_set_properties(jp_fetch, mock_gcloud_env):
-    updated_properties = {
-        "compute": {
-            "region": "updated-example-region",
-        },
-    }
-    update_response = await jp_fetch(
-        "gcloud", "config", "properties", method="POST", body=json.dumps(updated_properties))
-    assert update_response.code == 200
+async def test_set_properties(jp_fetch, mock_gcloud_properties):
+    with mock.patch(
+        "google.cloud.jupyter_config.config._async_run_gcloud_subcommand"
+    ) as mock_gcloud:
+        mock_gcloud.return_value = ""
+        updated_properties = {
+            "compute": {
+                "region": "updated-example-region",
+            },
+        }
+        update_response = await jp_fetch(
+            "gcloud", "config", "properties",
+            method="POST", body=json.dumps(updated_properties),
+        )
+        assert update_response.code == 200
+        mock_gcloud.assert_called_once_with("config set compute/region updated-example-region")
 
-    get_response = await jp_fetch("gcloud", "config", "properties")
-    assert get_response.code == 200
-    properties = json.loads(get_response.body)
 
-    assert properties["compute"]["region"] == "updated-example-region"
-
-
-async def test_set_invalid_property(jp_fetch, mock_gcloud_env):
+async def test_set_invalid_property(jp_fetch, mock_gcloud_properties):
     updated_properties = {
         "compute; true": {
             "region": "updated-example-region",
@@ -113,7 +105,7 @@ async def test_set_invalid_property(jp_fetch, mock_gcloud_env):
         assert err.code == 400
 
 
-async def test_set_invalid_nested_property(jp_fetch, mock_gcloud_env):
+async def test_set_invalid_nested_property(jp_fetch, mock_gcloud_properties):
     updated_properties = {
         "compute": {
             "region; true": "updated-example-region",
@@ -127,7 +119,7 @@ async def test_set_invalid_nested_property(jp_fetch, mock_gcloud_env):
         assert err.code == 400
 
 
-async def test_set_invalid_property_value(jp_fetch, mock_gcloud_env):
+async def test_set_invalid_property_value(jp_fetch, mock_gcloud_properties):
     updated_properties = {
         "compute": {
             "region": "updated-example-region; true",

--- a/google-cloud-jupyter-config/google/cloud/jupyter_config/tokenrenewer.py
+++ b/google-cloud-jupyter-config/google/cloud/jupyter_config/tokenrenewer.py
@@ -12,37 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
-import subprocess
-import sys
-import tempfile
 import typing
 
-
-from abc import abstractmethod
-from traitlets import Int, Unicode
+import google.auth
+import google.auth.transport.requests
 from jupyter_server.gateway.gateway_client import GatewayTokenRenewerBase
 
 
-class CachedTokenRenewerBase(GatewayTokenRenewerBase):
-    """Token renewer base class that only renews the token after a specified timeout."""
+class GoogleAuthTokenRenewer(GatewayTokenRenewerBase):
+    """Token renewer that uses Application Default Credentials via the google-auth library.
 
-    token_lifetime_seconds = Int(
-        default_value=300,
-        config=True,
-        help="""Time (in seconds) to wait between successive token renewals.""",
-    )
+    This replaces the previous approach of shelling out to `gcloud` to obtain
+    access tokens. Credentials are obtained via google.auth.default(), which
+    supports service accounts, user credentials (from `gcloud auth application-default login`),
+    and metadata-server credentials on GCE/Cloud Run/etc.
+    """
 
-    @abstractmethod
-    def force_new_token(
-        self,
-        auth_header_key: str,
-        auth_scheme: typing.Union[str, None],
-        **kwargs: typing.Any,
-    ):
-        pass
-
-    _created = datetime.datetime.min
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._credentials, _ = google.auth.default(
+            scopes=["https://www.googleapis.com/auth/cloud-platform"]
+        )
+        self._request = google.auth.transport.requests.Request()
 
     def get_token(
         self,
@@ -51,44 +42,6 @@ class CachedTokenRenewerBase(GatewayTokenRenewerBase):
         auth_token: str,
         **kwargs: typing.Any,
     ):
-        current_time = datetime.datetime.now()
-        duration = (current_time - self._created).total_seconds()
-        if (not auth_token) or (duration > self.token_lifetime_seconds):
-            auth_token = self.force_new_token(auth_header_key, auth_scheme, **kwargs)
-            self._created = datetime.datetime.now()
-
-        return auth_token
-
-
-class CommandTokenRenewer(CachedTokenRenewerBase):
-    """Token renewer that invokes an external command to generate the token."""
-
-    token_command = Unicode(
-        default_value="",
-        config=True,
-        help="""External command run to generate auth tokens.""",
-    )
-
-    def force_new_token(
-        self,
-        auth_header_key: str,
-        auth_scheme: typing.Union[str, None],
-        **kwargs: typing.Any,
-    ):
-        """Run the specified command to generate a new token, which is taken from its output.
-
-        We reuse the system stderr for the command so that any prompts from it
-        will be displayed to the user.
-        """
-        with tempfile.TemporaryFile() as t:
-            p = subprocess.run(
-                self.token_command,
-                stdin=subprocess.DEVNULL,
-                stderr=sys.stderr,
-                stdout=t,
-                check=True,
-                shell=True,
-                encoding="UTF-8",
-            )
-            t.seek(0)
-            return t.read().decode("UTF-8").strip()
+        if not self._credentials.valid:
+            self._credentials.refresh(self._request)
+        return self._credentials.token

--- a/google-cloud-jupyter-config/setup.py
+++ b/google-cloud-jupyter-config/setup.py
@@ -28,9 +28,10 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(),
     python_requires=">=3.8",
     install_requires=[
-        "cachetools",
+        "google-auth",
+        "google-cloud-resource-manager",
         "jupyter_server>=2.4.0",
-        "traitlets",
+        "requests",
     ],
     include_package_data=True,
     data_files=[(


### PR DESCRIPTION
Using the SDK would eliminate:
  - All subprocess spawn overhead (the biggest perf issue in this codebase)
  - The Windows ProcessPoolExecutor workaround entirely
  - The shell injection security vulnerabilities
  - The tempfile / subprocess.PIPE dance
  - The TTL cache for subprocess output (the SDK handles token refresh natively)
  - The requirement that gcloud CLI is even installed

  The google-auth library is especially relevant — google.auth.default() returns
  credentials that auto-refresh, so the entire CommandTokenRenewer with its background
   threads and caching could be replaced with a few lines. The google-cloud-storage
  package (already a dependency) transitively depends on google-auth, so it's already
  installed.


Replace the heavyweight approach of shelling out to the gcloud CLI for authentication and configuration with native Python libraries:

Credentials & tokens (tokenrenewer.py):
- Remove CachedTokenRenewerBase and CommandTokenRenewer classes that ran `gcloud config config-helper` via subprocess to obtain access tokens
- Add GoogleAuthTokenRenewer that uses google.auth.default() to obtain Application Default Credentials and credentials.refresh() to keep them valid, eliminating subprocess overhead entirely

Project & account configuration (config.py):
- gcp_credentials(): now uses google.auth.default() + credentials.refresh() instead of parsing gcloud config-helper JSON output
- gcp_project(): uses the project from ADC (google.auth.default), falling back to reading the gcloud properties file directly via configparser
- gcp_account(), gcp_region(): read the gcloud CLI properties file (~/.config/gcloud/configurations/config_<active>) directly with configparser instead of invoking gcloud as a subprocess
- gcp_project_number(): uses the google-cloud-resource-manager API (resourcemanager_v3.ProjectsClient) instead of `gcloud projects describe`
- PropertiesHandler.get: reads gcloud properties file directly instead of invoking `gcloud config config-helper`
- PropertiesHandler.post: still uses `gcloud config set` via subprocess as there is no Python API equivalent for writing gcloud CLI config

Removed infrastructure no longer needed:
- cachetools TTL cache and threading.Lock for caching gcloud output
- ProcessPoolExecutor pool for Windows async subprocess workaround
- run_gcloud_subcommand, async_run_gcloud_subcommand, cached_gcloud_subcommand, clear_gcloud_cache, get_gcloud_config, async_get_gcloud_config functions
- _run_gcloud_subcommand_via_process_pool_executor helper

Dependencies (setup.py):
- Added: google-auth, google-cloud-resource-manager, requests
- Removed: cachetools, traitlets

Tests (config_test.py, conftest.py):
- Replace CLOUDSDK_* environment variable mocking with mock_gcloud_properties fixture that creates a real configparser-formatted gcloud config directory
- Mock google.auth calls for credential and project tests
- Mock _async_run_gcloud_subcommand for property-setting tests