### PR TITLE
[kernels-mixer] Verify outbound websocket connections

### DIFF
--- a/kernels-mixer/kernels_mixer/websockets.py
+++ b/kernels-mixer/kernels_mixer/websockets.py
@@ -12,16 +12,117 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import datetime
 import json
 import uuid
 
+import tornado.gen as tornado_gen
 from tornado.escape import json_decode, utf8
+import tornado.websocket as tornado_websocket
 
+import jupyter_server.gateway.connections
 from jupyter_server.gateway.connections import GatewayWebSocketConnection
 from jupyter_server.gateway.managers import GatewayKernelManager
 from jupyter_server.services.kernels.connection.base import BaseKernelWebsocketConnection
 from jupyter_server.services.kernels.connection.channels import ZMQChannelsWebsocketConnection
+
+
+class _InterceptedTornadoWebsocket:
+    """Object to return from monkey-patched tornado.websocket.websocket_connect.
+    
+    We monkey-patch the tornado method used to create outbound websocket
+    connections to remote kernels so that it verifies the kernel can
+    communicate over those connections.
+    
+    We've seen sporadic issues where the outbound websocket connection appears to
+    be 'stuck'; messages make it back to the kernel's ZMQ channel but no responses
+    from the kernel get sent back on the ZMQ channel.
+    
+    When we've seen that, killing and recreating the connection seems to mitigate
+    the problem.
+    
+    To automate this, we verify that the outbound connection isn't 'stuck' before
+    we return it. In case it is stuck, we raise an error so that the connection
+    gets retried by the caller.
+    
+    The only place in the Jupyter server codebase that calls the method
+    'tornado.websocket.websocket_connect' is in the GatewayWebSocketConnection
+    class. That means we can monkey patch the method by modifying the value
+    imported in that class.
+    
+    It also means that all such outbound connections are only being made to kernel
+    messaging channels. As such, it is safe to assume that all connections created
+    using our patched method will only be for communicating with the remote
+    kernels, and we can inject kernel_info_request messages to probe the health of
+    those connections without risk of breaking anything.
+    
+    Since we are intercepting initial communications with the kernel, any messages
+    sent by the kernel before we get back our 'kernel_info_reply' message will get
+    dropped.
+    
+    That should be OK because the only such message we actually expect the kernel
+    to send is an initial 'status' message with an 'execution_state' of
+    'starting'. Such a message is only sent once at process startup time, so
+    clients aren't guaranteed to receive it anyway (they would have to connect
+    before the one time the message is sent).
+    """
+
+    def __init__(self, log):
+        self.log = log
+
+    WebSocketClientConnection = tornado_websocket.WebSocketClientConnection
+    WebSocketClosedError = tornado_websocket.WebSocketClosedError
+
+    async def _websocket_connect(self, *args, **kwargs):
+        """Connect websocket and wait for kernel info response."""
+        conn = await tornado_websocket.websocket_connect(*args, **kwargs)
+
+        self.log.debug('Verifying that the created connection is responsive...')
+        session_id = uuid.uuid4().hex
+        message_id = uuid.uuid4().hex
+        conn.write_message(
+            json.dumps({
+                'channel': 'shell',
+                'header': {
+                    'date': datetime.datetime.now().isoformat(),
+                    'session': session_id,
+                    'msg_id': message_id,
+                    'msg_type': 'kernel_info_request',
+                    'username': '',
+                    'version': '5.2',
+                },
+                'parent_header': {},
+                'metadata': {},
+                'content': {},
+                'buffers': [],
+            })
+        )
+        for _ in range(30):
+            try:
+                msg = await tornado_gen.with_timeout(
+                    datetime.timedelta(seconds=1), conn.read_message()
+                )
+            except TimeoutError:
+                self.log.debug(
+                    'Timeout waiting for a response message from the backend'
+                    ' websocket connection'
+                )
+                continue
+            if not msg:
+                self.log.error('Kernel connection closed on the backend')
+                raise RuntimeError('Kernel connection closed on the backend')
+            resp = json.loads(msg)
+            response_type = resp.get('header', {}).get('msg_type', None)
+            if response_type == 'kernel_info_reply':
+                self.log.debug('Kernel info reply received... returning connection')
+                return conn
+        self.log.error('Kernel connection did not respond to info requests')
+        raise RuntimeError('Kernel connection did not respond to info requests')
+
+    def websocket_connect(self, *args, **kwargs):
+        return asyncio.ensure_future(self._websocket_connect(*args, **kwargs))
+
 
 class StartingReportingWebsocketConnection(GatewayWebSocketConnection):
     """Extension of GatewayWebSocketConnection that reports a starting status on connection.
@@ -52,8 +153,15 @@ class StartingReportingWebsocketConnection(GatewayWebSocketConnection):
     also intercept any "starting" messages received from the kernel and discard
     them, as we know we will have already reported this status.
     """
+
+    patched_websocket_connect = False
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if not StartingReportingWebsocketConnection.patched_websocket_connect:
+            self.log.debug("Patching the Tornado websocket_connect method to verify connectivity")
+            jupyter_server.gateway.connections.tornado_websocket = _InterceptedTornadoWebsocket(self.log)
+            StartingReportingWebsocketConnection.patched_websocket_connect = True
 
     async def connect(self):
         # The kernel message format is defined

--- a/kernels-mixer/setup.py
+++ b/kernels-mixer/setup.py
@@ -18,7 +18,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
   name="kernels-mixer",
-  version="0.0.15",
+  version="0.0.16",
   author="Google, Inc.",
   description="Jupyter server extension that allows mixing local and remote kernels together",
   long_description=long_description,


### PR DESCRIPTION
This change patches the tornado.websocket_connect method used by the Jupyter Server's gateway_client to create outbound websocket connections.

The patched version verifies that the outbound connection is responsive before returning it to the caller.

This is necessary because we've found cases where it looks like the ZMQ channel underlying one of these connections gets "stuck"; messages are sent out on the ZMQ channel, but no responses from the kernel are ever read back.

When that happens, recreating the connection seems to fix the issue, so our patch automates that process.