### PR TITLE
[google-cloud-jupyter-config] Fix bug in calling CalledProcessError

### DIFF
--- a/google-cloud-jupyter-config/google/cloud/jupyter_config/config.py
+++ b/google-cloud-jupyter-config/google/cloud/jupyter_config/config.py
@@ -57,7 +57,7 @@ def run_gcloud_subcommand(subcmd):
                 errt.seek(0)
                 stdout = t.read().decode("UTF-8").strip()
                 stderr = errt.read().decode("UTF-8").strip()
-                raise subprocess.CalledProcessError(err.returncode, err.cmd, None, stdout, stderr)
+                raise subprocess.CalledProcessError(err.returncode, err.cmd, stdout, stderr)
         t.seek(0)
         return t.read().decode("UTF-8").strip()
 
@@ -112,7 +112,7 @@ async def async_run_gcloud_subcommand(subcmd):
             stdout = t.read().decode("UTF-8").strip()
             stderr = errt.read().decode("UTF-8").strip()
             if p.returncode != 0:
-                raise subprocess.CalledProcessError(p.returncode, cmd, None, stdout, stderr)
+                raise subprocess.CalledProcessError(p.returncode, cmd, stdout, stderr)
             return stdout
 
 


### PR DESCRIPTION
Previously, were were passing too many arguments to the `CalledProcessError` constructor.

I had seen from [the docs](https://docs.python.org/3/library/subprocess.html#subprocess.CalledProcessError) that it has 5 fields, and mistakenly thought that meant it takes 5 arguments in the constructor, but in actuality the `stdout` field is just an alias for `output`, and it really only takes 4 arguments (returncode, cmd, output, and stderr).