### PR TITLE
Use traitlets to support external kernel, kernelspec managers

### DIFF
--- a/kernels-mixer/kernels_mixer/kernels.py
+++ b/kernels-mixer/kernels_mixer/kernels.py
@@ -21,7 +21,7 @@ from jupyter_server.gateway.managers import GatewayMappingKernelManager
 from jupyter_server.services.kernels.kernelmanager import AsyncMappingKernelManager
 from jupyter_server.services.kernels.kernelmanager import ServerKernelManager
 
-from traitlets import Instance, default, observe
+from traitlets import Instance, Type, default, observe
 
 from .kernelspecs import MixingKernelSpecManager
 
@@ -45,6 +45,15 @@ class MixingMappingKernelManager(AsyncMappingKernelManager):
     @default("kernel_manager_class")
     def _default_kernel_manager_class(self):
         return "kernels_mixer.kernels.MixingKernelManager"
+
+    remote_kernel_manager_class = Type(
+        config=True,
+        default_value=GatewayMappingKernelManager,
+        help="""
+        The kernel manager class to use for remote kernels.
+
+        Must be a subclass of `jupyter_server.gateway.managers.GatewayMappingKernelManager`.""",
+    )
     
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -58,7 +67,7 @@ class MixingMappingKernelManager(AsyncMappingKernelManager):
             kernel_spec_manager=self.kernel_spec_manager.local_manager)
 
         # Set up the remote kernel management.
-        self.remote_manager = GatewayMappingKernelManager(
+        self.remote_manager = self.remote_kernel_manager_class(
             parent=self.parent,
             log=self.log,
             connection_dir=self.connection_dir,

--- a/kernels-mixer/kernels_mixer/kernelspecs.py
+++ b/kernels-mixer/kernels_mixer/kernelspecs.py
@@ -58,10 +58,19 @@ class MixingKernelSpecManager(KernelSpecManager):
         Must be a subclass of `jupyter_client.kernelspec.KernelSpecManager`.""",
     )
 
+    remote_kernel_spec_manager_class = Type(
+        config=True,
+        default_value=GatewayKernelSpecManager,
+        help="""
+        The kernel spec manager class to use for remote kernels.
+
+        Must be a subclass of `jupyter_server.gateway.managers.GatewayKernelSpecManager`.""",
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.local_manager = self.local_kernel_spec_manager_class(*args, **kwargs)
-        self.remote_manager= GatewayKernelSpecManager(*args, **kwargs)
+        self.remote_manager = self.remote_kernel_spec_manager_class(*args, **kwargs)
         self._local_kernels = set()
         self._remote_kernels = set()
 

--- a/kernels-mixer/kernels_mixer/websockets.py
+++ b/kernels-mixer/kernels_mixer/websockets.py
@@ -21,9 +21,10 @@ import tornado.gen as tornado_gen
 from tornado.escape import json_decode, utf8
 import tornado.websocket as tornado_websocket
 
+from traitlets import Type
+
 import jupyter_server.gateway.connections
 from jupyter_server.gateway.connections import GatewayWebSocketConnection
-from jupyter_server.gateway.managers import GatewayKernelManager
 from jupyter_server.services.kernels.connection.base import BaseKernelWebsocketConnection
 from jupyter_server.services.kernels.connection.channels import ZMQChannelsWebsocketConnection
 
@@ -215,11 +216,18 @@ class DelegatingWebsocketConnection(BaseKernelWebsocketConnection):
     Otherwise, it is an instance of ZMQChannelsWebsocketConnection.
     """
 
+    remote_websocket_connection_class = Type(
+        default_value=StartingReportingWebsocketConnection,
+        klass=GatewayWebSocketConnection,
+        config=True,
+        help="Class to use for remote Gateway WebSocket connections.",
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         delegate_class = ZMQChannelsWebsocketConnection
         if self.kernel_manager.is_remote:
-            delegate_class = StartingReportingWebsocketConnection
+            delegate_class = self.remote_websocket_connection_class
         self.delegate = delegate_class(
             parent=self.kernel_manager.delegate,
             websocket_handler=self.websocket_handler,


### PR DESCRIPTION
# [kernels-mixer] Make remote manager and websocket connection classes configurable via traitlets

Replaces the remote kernel and kernelspec manager classes with configurable Traitlets. This allows the `dataproc-jupyter-plugin` to inject custom managers via configuration.

  * Added `remote_kernel_spec_manager_class` traitlet on `MixingKernelSpecManager` (defaulting to standard Jupyter `GatewayKernelSpecManager`).
  * Added `remote_kernel_manager_class` traitlet on `MixingMappingKernelManager` (defaulting to standard Jupyter `GatewayMappingKernelManager`).
  * Added `remote_websocket_connection_class` traitlet on `DelegatingWebsocketConnection` (defaulting to `StartingReportingWebsocketConnection`).
