### PR TITLE
[kernels-mixer] better support for reconnections to kernels.

### DIFF
--- a/kernels-mixer/kernels_mixer/websockets.py
+++ b/kernels-mixer/kernels_mixer/websockets.py
@@ -15,6 +15,9 @@
 import asyncio
 import datetime
 import json
+import queue
+import threading
+import time
 import uuid
 
 import tornado.gen as tornado_gen
@@ -27,6 +30,36 @@ import jupyter_server.gateway.connections
 from jupyter_server.gateway.connections import GatewayWebSocketConnection
 from jupyter_server.services.kernels.connection.base import BaseKernelWebsocketConnection
 from jupyter_server.services.kernels.connection.channels import ZMQChannelsWebsocketConnection
+
+
+class _BufferedConnection(tornado_websocket.WebSocketClientConnection):
+    """Object that wraps a WebSocketClientConnection and adds a buffer of previous messages to replay.
+    """
+    def __init__(self, conn: tornado_websocket.WebSocketClientConnection, buffered_messages: queue.Queue):
+        self._conn = conn
+        self._buffered_messages = buffered_messages
+
+    @property
+    def selected_subprotocol(self):
+        return conn.selected_subprotocol
+
+    def close(self, *args, **kwargs):
+        return self._conn.close(*args, **kwargs)
+
+    def ping(self, *args, **kwargs):
+        return self._conn.ping(*args, **kwargs)
+
+    def write_message(self, *args, **kwargs):
+        return self._conn.write_message(*args, **kwargs)
+
+    async def read_message(self, callback=None):
+        if not self._buffered_messages.empty():
+            msg = self._buffered_messages.get()
+            if callback:
+                callback(msg)
+                return None
+            return msg
+        return await self._conn.read_message()
 
 
 class _InterceptedTornadoWebsocket:
@@ -78,13 +111,14 @@ class _InterceptedTornadoWebsocket:
     async def _websocket_connect(self, *args, **kwargs):
         """Connect websocket and wait for kernel info response."""
         conn = await tornado_websocket.websocket_connect(*args, **kwargs)
+        buffered_messages = []
 
         self.log.debug('Verifying that the created connection is responsive...')
         session_id = uuid.uuid4().hex
         message_id = uuid.uuid4().hex
         conn.write_message(
             json.dumps({
-                'channel': 'shell',
+                'channel': 'control',
                 'header': {
                     'date': datetime.datetime.now().isoformat(),
                     'session': session_id,
@@ -99,7 +133,8 @@ class _InterceptedTornadoWebsocket:
                 'buffers': [],
             })
         )
-        for _ in range(30):
+        time_limit = time.time() + 30  # Give up to 30 seconds for a message to come back.
+        while time.time() < time_limit:
             try:
                 msg = await tornado_gen.with_timeout(
                     datetime.timedelta(seconds=1), conn.read_message()
@@ -115,9 +150,16 @@ class _InterceptedTornadoWebsocket:
                 raise RuntimeError('Kernel connection closed on the backend')
             resp = json.loads(msg)
             response_type = resp.get('header', {}).get('msg_type', None)
-            if response_type == 'kernel_info_reply':
+            parent_id = resp.get('parent_header', {}).get('msg_id', '')
+            if response_type == 'kernel_info_reply' and parent_id == message_id:
                 self.log.debug('Kernel info reply received... returning connection')
-                return conn
+                msg_queue = queue.Queue(len(buffered_messages))
+                for msg in buffered_messages:
+                    msg_queue.put(msg)
+                return _BufferedConnection(conn, msg_queue)
+            else:
+                self.log.debug(f'Buffering non-status message {msg}')
+                buffered_messages.append(msg)
         self.log.error('Kernel connection did not respond to info requests')
         raise RuntimeError('Kernel connection did not respond to info requests')
 
@@ -156,6 +198,8 @@ class StartingReportingWebsocketConnection(GatewayWebSocketConnection):
     """
 
     patched_websocket_connect = False
+    seen_kernels_lock = threading.Lock()
+    seen_kernels = []
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -164,30 +208,45 @@ class StartingReportingWebsocketConnection(GatewayWebSocketConnection):
             jupyter_server.gateway.connections.tornado_websocket = _InterceptedTornadoWebsocket(self.log)
             StartingReportingWebsocketConnection.patched_websocket_connect = True
 
+    def has_seen_kernel_activity(self):
+        with StartingReportingWebsocketConnection.seen_kernels_lock:
+            return self.kernel_id in StartingReportingWebsocketConnection.seen_kernels
+
+    def record_kernel_activity(self):
+        with StartingReportingWebsocketConnection.seen_kernels_lock:
+            seen_kernels = [
+                k for k in StartingReportingWebsocketConnection.seen_kernels
+                if k != self.kernel_id]
+            seen_kernels.append(self.kernel_id)
+            seen_kernels = seen_kernels[max(0, len(seen_kernels)-1000):]
+            StartingReportingWebsocketConnection.seen_kernels = seen_kernels
+            return
+
     async def connect(self):
         # The kernel message format is defined
         # [here](https://jupyter-client.readthedocs.io/en/latest/messaging.html#general-message-format).
-        status_message_id = str(uuid.uuid4())
-        status_message = {
-            "header": {
+        if not self.has_seen_kernel_activity():
+            status_message_id = str(uuid.uuid4())
+            status_message = {
+                "header": {
+                    "msg_id": status_message_id,
+                    "session": self.kernel_id,
+                    "username": "username",
+                    "date": datetime.datetime.utcnow().isoformat(),
+                    "msg_type": "status",
+                    "version": "5.3",
+                },
+                "parent_header": {},
+                "metadata": {},
                 "msg_id": status_message_id,
-                "session": self.kernel_id,
-                "username": "username",
-                "date": datetime.datetime.utcnow().isoformat(),
                 "msg_type": "status",
-                "version": "5.3",
-            },
-            "parent_header": {},
-            "metadata": {},
-            "msg_id": status_message_id,
-            "msg_type": "status",
-            "channel": "iopub",
-            "content": {
-                "execution_state": "starting",
-            },
-            "buffers": [],
-        }
-        super().handle_outgoing_message(json.dumps(status_message))
+                "channel": "iopub",
+                "content": {
+                    "execution_state": "starting",
+                },
+                "buffers": [],
+            }
+            super().handle_outgoing_message(json.dumps(status_message))
         return await super().connect()
 
     def is_starting_message(self, incoming_msg):
@@ -200,6 +259,7 @@ class StartingReportingWebsocketConnection(GatewayWebSocketConnection):
         return False
 
     def handle_outgoing_message(self, incoming_msg, *args, **kwargs):
+        self.record_kernel_activity()
         if self.is_starting_message(incoming_msg):
             # We already sent a starting message, so drop this one.
             return

--- a/kernels-mixer/kernels_mixer/websockets.py
+++ b/kernels-mixer/kernels_mixer/websockets.py
@@ -41,7 +41,7 @@ class _BufferedConnection(tornado_websocket.WebSocketClientConnection):
 
     @property
     def selected_subprotocol(self):
-        return conn.selected_subprotocol
+        return self._conn.selected_subprotocol
 
     def close(self, *args, **kwargs):
         return self._conn.close(*args, **kwargs)
@@ -59,7 +59,7 @@ class _BufferedConnection(tornado_websocket.WebSocketClientConnection):
                 callback(msg)
                 return None
             return msg
-        return await self._conn.read_message()
+        return await self._conn.read_message(callback=callback)
 
 
 class _InterceptedTornadoWebsocket:
@@ -198,8 +198,10 @@ class StartingReportingWebsocketConnection(GatewayWebSocketConnection):
     """
 
     patched_websocket_connect = False
-    seen_kernels_lock = threading.Lock()
-    seen_kernels = []
+    _seen_kernels_lock = threading.Lock()
+    _seen_kernels = {}
+    _seen_kernels_upper_bound = 1000
+    _seen_kernels_cull_limit = 500
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -209,17 +211,19 @@ class StartingReportingWebsocketConnection(GatewayWebSocketConnection):
             StartingReportingWebsocketConnection.patched_websocket_connect = True
 
     def has_seen_kernel_activity(self):
-        with StartingReportingWebsocketConnection.seen_kernels_lock:
-            return self.kernel_id in StartingReportingWebsocketConnection.seen_kernels
+        with StartingReportingWebsocketConnection._seen_kernels_lock:
+            return self.kernel_id in StartingReportingWebsocketConnection._seen_kernels
 
     def record_kernel_activity(self):
-        with StartingReportingWebsocketConnection.seen_kernels_lock:
-            seen_kernels = [
-                k for k in StartingReportingWebsocketConnection.seen_kernels
-                if k != self.kernel_id]
-            seen_kernels.append(self.kernel_id)
-            seen_kernels = seen_kernels[max(0, len(seen_kernels)-1000):]
-            StartingReportingWebsocketConnection.seen_kernels = seen_kernels
+        with StartingReportingWebsocketConnection._seen_kernels_lock:
+            seen_kernels = StartingReportingWebsocketConnection._seen_kernels
+            seen_kernels[self.kernel_id] = datetime.datetime.utcnow()
+            if len(seen_kernels) > StartingReportingWebsocketConnection._seen_kernels_upper_bound:
+                timestamps = sorted([(t, k) for k, t in seen_kernels.items()])
+                kernels_to_drop = len(seen_kernels)-StartingReportingWebsocketConnection._seen_kernels_cull_limit
+                seen_kernels = dict([(k, t) for t, k in timestamps[max(0, kernels_to_drop):]])
+
+            StartingReportingWebsocketConnection._seen_kernels = seen_kernels
             return
 
     async def connect(self):

--- a/kernels-mixer/kernels_mixer/websockets_test.py
+++ b/kernels-mixer/kernels_mixer/websockets_test.py
@@ -18,6 +18,8 @@ import uuid
 
 import pytest
 
+from kernels_mixer.websockets import StartingReportingWebsocketConnection
+
 
 @pytest.fixture
 def test_kernel(jp_fetch):
@@ -92,3 +94,46 @@ async def test_websocket(jp_fetch, jp_ws_fetch, test_kernel):
 
     await close_and_drain_pending_messages(ws)
     raise AssertionError("Never got a response to the code execution")
+
+
+async def test_record_kernel_activity(jp_serverapp, test_kernel):
+    original_upper_bound = StartingReportingWebsocketConnection._seen_kernels_upper_bound
+    original_cull_limit = StartingReportingWebsocketConnection._seen_kernels_cull_limit
+    test_upper_bound = 10
+    test_cull_limit = 5
+    StartingReportingWebsocketConnection._seen_kernels_upper_bound = test_upper_bound
+    StartingReportingWebsocketConnection._seen_kernels_cull_limit = test_cull_limit
+    connections = {}
+    created_kernels = []
+
+    # Fill up the set of seen kernels as much as supported.
+    for _ in range(test_upper_bound):
+        k = await test_kernel()
+        kid = k["id"]
+        km = jp_serverapp.kernel_manager.get_kernel(kid)
+        conn = StartingReportingWebsocketConnection(parent=km)
+        conn.record_kernel_activity()
+        connections[kid] = conn
+        created_kernels.append(kid)
+    for (_, conn) in connections.items():
+        assert conn.has_seen_kernel_activity()
+
+    # Overfill the set of seen kernels.
+    expected_kernels = created_kernels[(len(created_kernels)-test_cull_limit)+1:]
+    for _ in range(test_cull_limit):
+        k = await test_kernel()
+        kid = k["id"]
+        km = jp_serverapp.kernel_manager.get_kernel(kid)
+        conn = StartingReportingWebsocketConnection(parent=km)
+        conn.record_kernel_activity()
+        connections[kid] = conn
+        expected_kernels.append(kid)
+
+    for (kid, conn) in connections.items():
+        if kid in expected_kernels:
+            assert conn.has_seen_kernel_activity()
+        else:
+            assert not conn.has_seen_kernel_activity()
+
+    StartingReportingWebsocketConnection._seen_kernels_upper_bound = original_upper_bound
+    StartingReportingWebsocketConnection._seen_kernels_cull_limit = original_cull_limit

--- a/kernels-mixer/setup.py
+++ b/kernels-mixer/setup.py
@@ -18,7 +18,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
   name="kernels-mixer",
-  version="0.0.16",
+  version="0.0.17",
   author="Google, Inc.",
   description="Jupyter server extension that allows mixing local and remote kernels together",
   long_description=long_description,


### PR DESCRIPTION
This commit adds four improvements for when the client reconnects to a kernel:

1. Don't send the `starting` status message for kernels that have already communicated with the client.

   This fixes an issue where the kernel status in the UI can change from `idle` or `busy` to `starting`.

2. Send the `kernel_info_request` used to health check the connection on the `control` channel instead of the `shell` channel.

   This prevents an issue where a large amount of shell messages coming back from the kernel (such as large amounts of stderr) can flood the `shell` channel and as a result block the `kernel_info_reply` message from coming back in a reasonable time.

3. Buffer any non `kernel_info_reply` messages seen during the connection health check and play them back after the connection is returned to the caller.

   This reduces the risk of messages getting dropped during the period between when a connection is dropped and the next one is created.

4. Poll for the `kernel_info_reply` for a fixed amount of time rather than a fixed number of messages.

    This similarly makes us more gracefully handle the scenario where the
    channel is being flooded with a very large number of messages.